### PR TITLE
Prevent ReflectionException when modelClass dont exist in AdminExtension...

### DIFF
--- a/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
@@ -29,6 +29,9 @@ class AdminExtensionCompilerPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $attributes) {
             $admin = $container->getDefinition($id);
             $modelClass = $container->getParameterBag()->resolveValue($admin->getArgument(1));
+            if(!class_exists($modelClass)){
+                continue;
+            }
             $modelClassReflection = new \ReflectionClass($modelClass);
 
             foreach ($adminExtensionReferences as $type => $reference) {


### PR DESCRIPTION
When using sonata page bundle a got ReflectionException because Application\Sonata\PageBundle\Entity\Post don't exist, any time i want to generate from easy-extends it throw the ReflectionException and i got a loop of error without solution because i can not create the Application\Sonata\PageBundle\Entity\Post class, with this it avoid the throw of Exception in the origin. 