### PR TITLE
[Fix] csslint standard rules disallow "0px" syntax on css files.

### DIFF
--- a/Resources/public/css/sonata-translation.css
+++ b/Resources/public/css/sonata-translation.css
@@ -1,25 +1,22 @@
 /**
  * SonataTranslation: adds translations to your forms
  */
-.sonata-bc {
-  /** Here if somebody could find how to do it easily for all the flags it would be awesome */
-}
 .sonata-bc .sonata-ba-form .locale_switcher {
-  padding: 1px 0px 0px 0px;
-  text-align: right;
-  margin-right: 15px;
-  float: right;
+    padding: 1px 0 0 0;
+    text-align: right;
+    margin-right: 15px;
+    float: right;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a {
-  margin-right: 0px;
-  padding: 2px;
-  opacity: 0.5;
+    margin-right: 0;
+    padding: 2px;
+    opacity: 0.5;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a.active {
-  opacity: 1;
+    opacity: 1;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a:hover {
-  opacity: 1;
+    opacity: 1;
 }
 .sonata-bc .sonata-ba-form label.wysiwyg.locale,
 .sonata-bc .sonata-ba-form label.checkbox.locale,
@@ -27,66 +24,33 @@
 .sonata-bc .sonata-ba-form textarea.locale,
 .sonata-bc .sonata-ba-form select.locale,
 .sonata-bc .sonata-ba-form li.locale a {
-  background-repeat: no-repeat;
+    background-repeat: no-repeat;
 }
 .sonata-bc .sonata-ba-form input[type="text"].locale,
 .sonata-bc .sonata-ba-form select.locale {
-  padding-left: 35px !important;
-  background-position: 5px center;
+    padding-left: 35px !important;
+    background-position: 5px center;
 }
 .sonata-bc .sonata-ba-form textarea.locale {
-  padding-left: 35px;
-  background-position: 5px 5px;
+    padding-left: 35px;
+    background-position: 5px 5px;
 }
 .sonata-bc .sonata-ba-form label.wysiwyg.locale,
 .sonata-bc .sonata-ba-form label.checkbox.locale {
-  padding-right: 35px;
-  background-position: right bottom;
+    padding-right: 35px;
+    background-position: right bottom;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"] {
-  /*top: 5px;*/
-  position: relative;
-  width: 15px;
+    /*top: 5px;*/
+    position: relative;
+    width: 15px;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"].locale {
-  width: 65px;
-  background-position: 0px center;
+    width: 65px;
+    background-position: 0 center;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"]:before {
-  margin-right: 35px;
-}
-.sonata-bc.locale_fr label.wysiwyg.locale,
-.sonata-bc.locale_fr label.checkbox.locale,
-.sonata-bc.locale_fr input.locale,
-.sonata-bc.locale_fr textarea.locale,
-.sonata-bc.locale_fr select.locale,
-.sonata-bc.locale_fr li.locale a {
-  background-image: url('/bundles/sonatatranslation/img/flags/fr.png');
-}
-.sonata-bc.locale_fr input[type="checkbox"].locale:before {
-  content: url('/bundles/sonatatranslation/img/flags/fr.png');
-}
-.sonata-bc.locale_en label.wysiwyg.locale,
-.sonata-bc.locale_en label.checkbox.locale,
-.sonata-bc.locale_en input.locale,
-.sonata-bc.locale_en textarea.locale,
-.sonata-bc.locale_en select.locale,
-.sonata-bc.locale_en li.locale a {
-  background-image: url('/bundles/sonatatranslation/img/flags/en.png');
-}
-.sonata-bc.locale_en input[type="checkbox"].locale:before {
-  content: url('/bundles/sonatatranslation/img/flags/en.png');
-}
-.sonata-bc.locale_it label.wysiwyg.locale,
-.sonata-bc.locale_it label.checkbox.locale,
-.sonata-bc.locale_it input.locale,
-.sonata-bc.locale_it textarea.locale,
-.sonata-bc.locale_it select.locale,
-.sonata-bc.locale_it li.locale a {
-  background-image: url('/bundles/sonatatranslation/img/flags/it.png');
-}
-.sonata-bc.locale_it input[type="checkbox"].locale:before {
-  content: url('/bundles/sonatatranslation/img/flags/it.png');
+    margin-right: 35px;
 }
 .sonata-bc.locale_nl label.wysiwyg.locale,
 .sonata-bc.locale_nl label.checkbox.locale,
@@ -94,10 +58,10 @@
 .sonata-bc.locale_nl textarea.locale,
 .sonata-bc.locale_nl select.locale,
 .sonata-bc.locale_nl li.locale a {
-  background-image: url('/bundles/sonatatranslation/img/flags/nl.png');
+    background-image: url('/bundles/sonatatranslation/img/flags/nl.png');
 }
 .sonata-bc.locale_nl input[type="checkbox"].locale:before {
-  content: url('/bundles/sonatatranslation/img/flags/nl.png');
+    content: url('/bundles/sonatatranslation/img/flags/nl.png');
 }
 .sonata-bc.locale_es label.wysiwyg.locale,
 .sonata-bc.locale_es label.checkbox.locale,
@@ -105,8 +69,41 @@
 .sonata-bc.locale_es textarea.locale,
 .sonata-bc.locale_es select.locale,
 .sonata-bc.locale_es li.locale a {
-  background-image: url('/bundles/sonatatranslation/img/flags/es.png');
+    background-image: url('/bundles/sonatatranslation/img/flags/es.png');
 }
 .sonata-bc.locale_es input[type="checkbox"].locale:before {
-  content: url('/bundles/sonatatranslation/img/flags/es.png');
+    content: url('/bundles/sonatatranslation/img/flags/es.png');
+}
+.sonata-bc.locale_it label.wysiwyg.locale,
+.sonata-bc.locale_it label.checkbox.locale,
+.sonata-bc.locale_it input.locale,
+.sonata-bc.locale_it textarea.locale,
+.sonata-bc.locale_it select.locale,
+.sonata-bc.locale_it li.locale a {
+    background-image: url('/bundles/sonatatranslation/img/flags/it.png');
+}
+.sonata-bc.locale_it input[type="checkbox"].locale:before {
+    content: url('/bundles/sonatatranslation/img/flags/it.png');
+}
+.sonata-bc.locale_en label.wysiwyg.locale,
+.sonata-bc.locale_en label.checkbox.locale,
+.sonata-bc.locale_en input.locale,
+.sonata-bc.locale_en textarea.locale,
+.sonata-bc.locale_en select.locale,
+.sonata-bc.locale_en li.locale a {
+    background-image: url('/bundles/sonatatranslation/img/flags/en.png');
+}
+.sonata-bc.locale_en input[type="checkbox"].locale:before {
+    content: url('/bundles/sonatatranslation/img/flags/en.png');
+}
+.sonata-bc.locale_fr label.wysiwyg.locale,
+.sonata-bc.locale_fr label.checkbox.locale,
+.sonata-bc.locale_fr input.locale,
+.sonata-bc.locale_fr textarea.locale,
+.sonata-bc.locale_fr select.locale,
+.sonata-bc.locale_fr li.locale a {
+    background-image: url('/bundles/sonatatranslation/img/flags/fr.png');
+}
+.sonata-bc.locale_fr input[type="checkbox"].locale:before {
+    content: url('/bundles/sonatatranslation/img/flags/fr.png');
 }

--- a/Resources/public/css/sonata-translation.css
+++ b/Resources/public/css/sonata-translation.css
@@ -2,21 +2,21 @@
  * SonataTranslation: adds translations to your forms
  */
 .sonata-bc .sonata-ba-form .locale_switcher {
-    padding: 1px 0 0 0;
-    text-align: right;
-    margin-right: 15px;
-    float: right;
+  padding: 1px 0 0 0;
+  text-align: right;
+  margin-right: 15px;
+  float: right;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a {
-    margin-right: 0;
-    padding: 2px;
-    opacity: 0.5;
+  margin-right: 0;
+  padding: 2px;
+  opacity: 0.5;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a.active {
-    opacity: 1;
+  opacity: 1;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a:hover {
-    opacity: 1;
+  opacity: 1;
 }
 .sonata-bc .sonata-ba-form label.wysiwyg.locale,
 .sonata-bc .sonata-ba-form label.checkbox.locale,
@@ -24,77 +24,33 @@
 .sonata-bc .sonata-ba-form textarea.locale,
 .sonata-bc .sonata-ba-form select.locale,
 .sonata-bc .sonata-ba-form li.locale a {
-    background-repeat: no-repeat;
+  background-repeat: no-repeat;
 }
 .sonata-bc .sonata-ba-form input[type="text"].locale,
 .sonata-bc .sonata-ba-form select.locale {
-    padding-left: 35px !important;
-    background-position: 5px center;
+  padding-left: 35px !important;
+  background-position: 5px center;
 }
 .sonata-bc .sonata-ba-form textarea.locale {
-    padding-left: 35px;
-    background-position: 5px 5px;
+  padding-left: 35px;
+  background-position: 5px 5px;
 }
 .sonata-bc .sonata-ba-form label.wysiwyg.locale,
 .sonata-bc .sonata-ba-form label.checkbox.locale {
-    padding-right: 35px;
-    background-position: right bottom;
+  padding-right: 35px;
+  background-position: right bottom;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"] {
-    /*top: 5px;*/
-    position: relative;
-    width: 15px;
+  /*top: 5px;*/
+  position: relative;
+  width: 15px;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"].locale {
-    width: 65px;
-    background-position: 0 center;
+  width: 65px;
+  background-position: 0 center;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"]:before {
-    margin-right: 35px;
-}
-.sonata-bc.locale_nl label.wysiwyg.locale,
-.sonata-bc.locale_nl label.checkbox.locale,
-.sonata-bc.locale_nl input.locale,
-.sonata-bc.locale_nl textarea.locale,
-.sonata-bc.locale_nl select.locale,
-.sonata-bc.locale_nl li.locale a {
-    background-image: url('/bundles/sonatatranslation/img/flags/nl.png');
-}
-.sonata-bc.locale_nl input[type="checkbox"].locale:before {
-    content: url('/bundles/sonatatranslation/img/flags/nl.png');
-}
-.sonata-bc.locale_es label.wysiwyg.locale,
-.sonata-bc.locale_es label.checkbox.locale,
-.sonata-bc.locale_es input.locale,
-.sonata-bc.locale_es textarea.locale,
-.sonata-bc.locale_es select.locale,
-.sonata-bc.locale_es li.locale a {
-    background-image: url('/bundles/sonatatranslation/img/flags/es.png');
-}
-.sonata-bc.locale_es input[type="checkbox"].locale:before {
-    content: url('/bundles/sonatatranslation/img/flags/es.png');
-}
-.sonata-bc.locale_it label.wysiwyg.locale,
-.sonata-bc.locale_it label.checkbox.locale,
-.sonata-bc.locale_it input.locale,
-.sonata-bc.locale_it textarea.locale,
-.sonata-bc.locale_it select.locale,
-.sonata-bc.locale_it li.locale a {
-    background-image: url('/bundles/sonatatranslation/img/flags/it.png');
-}
-.sonata-bc.locale_it input[type="checkbox"].locale:before {
-    content: url('/bundles/sonatatranslation/img/flags/it.png');
-}
-.sonata-bc.locale_en label.wysiwyg.locale,
-.sonata-bc.locale_en label.checkbox.locale,
-.sonata-bc.locale_en input.locale,
-.sonata-bc.locale_en textarea.locale,
-.sonata-bc.locale_en select.locale,
-.sonata-bc.locale_en li.locale a {
-    background-image: url('/bundles/sonatatranslation/img/flags/en.png');
-}
-.sonata-bc.locale_en input[type="checkbox"].locale:before {
-    content: url('/bundles/sonatatranslation/img/flags/en.png');
+  margin-right: 35px;
 }
 .sonata-bc.locale_fr label.wysiwyg.locale,
 .sonata-bc.locale_fr label.checkbox.locale,
@@ -102,8 +58,52 @@
 .sonata-bc.locale_fr textarea.locale,
 .sonata-bc.locale_fr select.locale,
 .sonata-bc.locale_fr li.locale a {
-    background-image: url('/bundles/sonatatranslation/img/flags/fr.png');
+  background-image: url('/bundles/sonatatranslation/img/flags/fr.png');
 }
 .sonata-bc.locale_fr input[type="checkbox"].locale:before {
-    content: url('/bundles/sonatatranslation/img/flags/fr.png');
+  content: url('/bundles/sonatatranslation/img/flags/fr.png');
+}
+.sonata-bc.locale_en label.wysiwyg.locale,
+.sonata-bc.locale_en label.checkbox.locale,
+.sonata-bc.locale_en input.locale,
+.sonata-bc.locale_en textarea.locale,
+.sonata-bc.locale_en select.locale,
+.sonata-bc.locale_en li.locale a {
+  background-image: url('/bundles/sonatatranslation/img/flags/en.png');
+}
+.sonata-bc.locale_en input[type="checkbox"].locale:before {
+  content: url('/bundles/sonatatranslation/img/flags/en.png');
+}
+.sonata-bc.locale_it label.wysiwyg.locale,
+.sonata-bc.locale_it label.checkbox.locale,
+.sonata-bc.locale_it input.locale,
+.sonata-bc.locale_it textarea.locale,
+.sonata-bc.locale_it select.locale,
+.sonata-bc.locale_it li.locale a {
+  background-image: url('/bundles/sonatatranslation/img/flags/it.png');
+}
+.sonata-bc.locale_it input[type="checkbox"].locale:before {
+  content: url('/bundles/sonatatranslation/img/flags/it.png');
+}
+.sonata-bc.locale_nl label.wysiwyg.locale,
+.sonata-bc.locale_nl label.checkbox.locale,
+.sonata-bc.locale_nl input.locale,
+.sonata-bc.locale_nl textarea.locale,
+.sonata-bc.locale_nl select.locale,
+.sonata-bc.locale_nl li.locale a {
+  background-image: url('/bundles/sonatatranslation/img/flags/nl.png');
+}
+.sonata-bc.locale_nl input[type="checkbox"].locale:before {
+  content: url('/bundles/sonatatranslation/img/flags/nl.png');
+}
+.sonata-bc.locale_es label.wysiwyg.locale,
+.sonata-bc.locale_es label.checkbox.locale,
+.sonata-bc.locale_es input.locale,
+.sonata-bc.locale_es textarea.locale,
+.sonata-bc.locale_es select.locale,
+.sonata-bc.locale_es li.locale a {
+  background-image: url('/bundles/sonatatranslation/img/flags/es.png');
+}
+.sonata-bc.locale_es input[type="checkbox"].locale:before {
+  content: url('/bundles/sonatatranslation/img/flags/es.png');
 }

--- a/Resources/public/less/sonata-translation.less
+++ b/Resources/public/less/sonata-translation.less
@@ -5,12 +5,12 @@
 
     .sonata-ba-form {
         .locale_switcher {
-            padding: 1px 0px 0px 0px;
+            padding: 1px 0 0 0;
             text-align: right;
             margin-right: 15px;
             float: right;
             a {
-                margin-right: 0px;
+                margin-right: 0;
                 padding: 2px;
                 opacity: 0.5;
 
@@ -50,7 +50,7 @@
 
             &.locale {
                 width: 65px;
-                background-position: 0px center;
+                background-position: 0 center;
             }
 
             &:before {


### PR DESCRIPTION
Hello,
i'm using your assets with grunt-csslint then standard rules (and css good practices) says that 0 values must not have unit.
NB : css was been redo with grunt-less (lessc inside)