### PR TITLE
Also check for PersonalTranslatable

### DIFF
--- a/Checker/TranslatableChecker.php
+++ b/Checker/TranslatableChecker.php
@@ -72,7 +72,11 @@ class TranslatableChecker
         }
 
         if (function_exists('class_uses')) {
-            if (in_array('Sonata\TranslationBundle\Traits\Translatable', class_uses($object))) {
+            $traits = class_uses($object);
+            if (in_array('Sonata\TranslationBundle\Traits\Translatable', $traits)) {
+                return true;
+            }
+            if (in_array('Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatable', $traits)) {
                 return true;
             }
         }


### PR DESCRIPTION
`Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatable` uses `Sonata\TranslationBundle\Traits\Translatable`, but `class_uses` will only return `PersonalTranslatable`, although it indirectly uses `Translatable`. I suggest also checking for `PersonalTranslatable` in `TranslatableChecker`. Maybe the traits could even be made configurable like the interfaces or the models.