### PR TITLE
Add TranslatableListener constructor parameter to Gedmo\TranslatableAdminExtension service

### DIFF
--- a/Admin/Extension/Gedmo/TranslatableAdminExtension.php
+++ b/Admin/Extension/Gedmo/TranslatableAdminExtension.php
@@ -14,6 +14,7 @@ namespace Sonata\TranslationBundle\Admin\Extension\Gedmo;
 use Gedmo\Translatable\TranslatableListener;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\TranslationBundle\Admin\Extension\AbstractTranslatableAdminExtension;
+use Sonata\TranslationBundle\Checker\TranslatableChecker;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
@@ -25,19 +26,19 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
      */
     protected $translatableListener;
 
+    public function __construct(TranslatableChecker $translatableChecker, TranslatableListener $translatableListener)
+    {
+        parent::__construct($translatableChecker);
+        $this->translatableListener = $translatableListener;
+    }
+
     /**
      * @param AdminInterface $admin
      *
      * @return TranslatableListener
      */
-    protected function getTranslatableListener(AdminInterface $admin)
+    protected function getTranslatableListener()
     {
-        if ($this->translatableListener == null) {
-            $this->translatableListener = $this->getContainer($admin)->get(
-                'stof_doctrine_extensions.listener.translatable'
-            );
-        }
-
         return $this->translatableListener;
     }
 
@@ -47,8 +48,8 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
     public function alterObject(AdminInterface $admin, $object)
     {
         if ($this->getTranslatableChecker()->isTranslatable($object)) {
-            $this->getTranslatableListener($admin)->setTranslatableLocale($this->getTranslatableLocale($admin));
-            $this->getTranslatableListener($admin)->setTranslationFallback('');
+            $this->getTranslatableListener()->setTranslatableLocale($this->getTranslatableLocale($admin));
+            $this->getTranslatableListener()->setTranslationFallback('');
 
             $this->getContainer($admin)->get('doctrine')->getManager()->refresh($object);
             $object->setLocale($this->getTranslatableLocale($admin));

--- a/Resources/config/service_gedmo.xml
+++ b/Resources/config/service_gedmo.xml
@@ -12,7 +12,9 @@
         <service id="sonata_translation.admin.extension.gedmo_translatable" class="%sonata_translation.admin.extension.gedmo_translatable.class%">
             <tag name="sonata.admin.extension" />
             <argument type="service" id="sonata_translation.checker.translatable" />
+            <argument type="service" id="sonata_translation.listener.translatable" />
         </service>
+        <service id="sonata_translation.listener.translatable" alias="stof_doctrine_extensions.listener.translatable" />
     </services>
 
 </container>


### PR DESCRIPTION
The service `stof_doctrine_extensions.listener.translatable` is no longer available as a public service and can't be retrieved by name anymore.
It is now injected as constructor parameter in `Sonata\TranslationBundle\Admin\Extension\Gedmo\TranslatableAdminExtension` using the alias
`sonata_translation.listener.translatable`.

Fixes #58

@nicolas-bastien 