### PR TITLE
[PHPCR] Make it possible to create new languages of a document

### DIFF
--- a/Admin/Extension/Phpcr/TranslatableAdminExtension.php
+++ b/Admin/Extension/Phpcr/TranslatableAdminExtension.php
@@ -40,8 +40,21 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
         $unitOfWork         = $documentManager->getUnitOfWork();
 
         if ($this->getTranslatableChecker()->isTranslatable($object) && ($unitOfWork->getCurrentLocale($object) != $locale)) {
-            //@dbu : doesn't work - $documentManager->bindTranslation($object, $locale);
             $object = $this->getDocumentManager($admin)->findTranslation($admin->getClass(), $object->getId(), $locale);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preUpdate(AdminInterface $admin, $object)
+    {
+        $locale          = $this->getTranslatableLocale($admin);
+        $documentManager = $this->getDocumentManager($admin);
+        $unitOfWork      = $documentManager->getUnitOfWork();
+
+        if ($this->getTranslatableChecker()->isTranslatable($object) && ($unitOfWork->getCurrentLocale($object) != $locale)) {
+            $documentManager->bindTranslation($object, $locale);
         }
     }
 }

--- a/Admin/Extension/Phpcr/TranslatableAdminExtension.php
+++ b/Admin/Extension/Phpcr/TranslatableAdminExtension.php
@@ -35,26 +35,21 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
      */
     public function alterObject(AdminInterface $admin, $object)
     {
-        $locale             = $this->getTranslatableLocale($admin);
-        $documentManager    = $this->getDocumentManager($admin);
-        $unitOfWork         = $documentManager->getUnitOfWork();
-
-        if ($this->getTranslatableChecker()->isTranslatable($object) && ($unitOfWork->getCurrentLocale($object) != $locale)) {
-            $object = $this->getDocumentManager($admin)->findTranslation($admin->getClass(), $object->getId(), $locale);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function preUpdate(AdminInterface $admin, $object)
-    {
-        $locale          = $this->getTranslatableLocale($admin);
+        $locale = $this->getTranslatableLocale($admin);
         $documentManager = $this->getDocumentManager($admin);
-        $unitOfWork      = $documentManager->getUnitOfWork();
+        $unitOfWork = $documentManager->getUnitOfWork();
 
-        if ($this->getTranslatableChecker()->isTranslatable($object) && ($unitOfWork->getCurrentLocale($object) != $locale)) {
-            $documentManager->bindTranslation($object, $locale);
+        if (
+            $this->getTranslatableChecker()->isTranslatable($object)
+            && ($unitOfWork->getCurrentLocale($object) !== $locale)
+        ) {
+            $object = $this->getDocumentManager($admin)->findTranslation($admin->getClass(), $object->getId(), $locale);
+
+            // if the translation did not yet exists, the locale will be
+            // the fallback locale. This makes sure the new locale is set.
+            if ($unitOfWork->getCurrentLocale($object) !== $locale) {
+                $documentManager->bindTranslation($object, $locale);
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, it is impossible to add a new translation of a document using the admin fields. With this patch, adding new translations is possible.

Fixes https://github.com/symfony-cmf/cmf-sandbox/issues/323