### PR TITLE
make gedmo extension changes backwards compatible

### DIFF
--- a/Admin/Extension/Gedmo/TranslatableAdminExtension.php
+++ b/Admin/Extension/Gedmo/TranslatableAdminExtension.php
@@ -26,19 +26,25 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
      */
     protected $translatableListener;
 
-    public function __construct(TranslatableChecker $translatableChecker, TranslatableListener $translatableListener)
+    public function __construct(TranslatableChecker $translatableChecker, TranslatableListener $translatableListener = null)
     {
         parent::__construct($translatableChecker);
         $this->translatableListener = $translatableListener;
     }
 
     /**
-     * @param AdminInterface $admin
+     * @param AdminInterface $admin Deprecated, set TranslatableListener in the constructor instead.
      *
      * @return TranslatableListener
      */
-    protected function getTranslatableListener()
+    protected function getTranslatableListener(AdminInterface $admin)
     {
+        if (null === $this->translatableListener) {
+            $this->translatableListener = $this->getContainer($admin)->get(
+                'stof_doctrine_extensions.listener.translatable'
+            );
+        }
+
         return $this->translatableListener;
     }
 
@@ -48,8 +54,9 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
     public function alterObject(AdminInterface $admin, $object)
     {
         if ($this->getTranslatableChecker()->isTranslatable($object)) {
-            $this->getTranslatableListener()->setTranslatableLocale($this->getTranslatableLocale($admin));
-            $this->getTranslatableListener()->setTranslationFallback('');
+            $translatableListener = $this->getTranslatableListener($admin);
+            $translatableListener->setTranslatableLocale($this->getTranslatableLocale($admin));
+            $translatableListener->setTranslationFallback('');
 
             $this->getContainer($admin)->get('doctrine')->getManager()->refresh($object);
             $object->setLocale($this->getTranslatableLocale($admin));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 CHANGELOG
 =========
 
-1.0.1
+1.0.2
 -----
 
+* **2016-03-29**: Prepared Gedmo TranslatableAdminExtension for simplification in version 2.0
+  *Note*: If you used the dev version and extended TranslatableAdminExtension::getTranslatableListener(AdminInterface $admin) you might need some adaptions as the parameter was removed for a while.
 
+1.0.1
+-----
 
 1.0.0
 -----


### PR DESCRIPTION
there has been a BC break after 1.0.1 that has not been released yet.