### PR TITLE
#81 add translation on list and on filters

### DIFF
--- a/Admin/Extension/Gedmo/TranslatableAdminExtension.php
+++ b/Admin/Extension/Gedmo/TranslatableAdminExtension.php
@@ -11,10 +11,10 @@
 
 namespace Sonata\TranslationBundle\Admin\Extension\Gedmo;
 
-use Doctrine\DBAL\Query\QueryBuilder;
 use Gedmo\Translatable\TranslatableListener;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\TranslationBundle\Admin\Extension\AbstractTranslatableAdminExtension;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 
@@ -71,14 +71,14 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
      * Search on normal field and on translation field
      * To use with a doctrine_orm_callback filter type.
      *
-     * @param QueryBuilder $queryBuilder
-     * @param string       $alias
-     * @param string       $field
-     * @param string       $value
+     * @param ProxyQuery $queryBuilder
+     * @param string     $alias
+     * @param string     $field
+     * @param string     $value
      *
      * @return bool
      */
-    public static function translationFieldFilter(QueryBuilder $queryBuilder, $alias, $field, $value)
+    public static function translationFieldFilter(ProxyQuery $queryBuilder, $alias, $field, $value)
     {
         if (!$value['value']) {
             return;

--- a/Admin/Extension/Gedmo/TranslatableAdminExtension.php
+++ b/Admin/Extension/Gedmo/TranslatableAdminExtension.php
@@ -11,13 +11,12 @@
 
 namespace Sonata\TranslationBundle\Admin\Extension\Gedmo;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Gedmo\Translatable\TranslatableListener;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\TranslationBundle\Admin\Extension\AbstractTranslatableAdminExtension;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
-use Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
@@ -70,15 +69,16 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
 
     /**
      * Search on normal field and on translation field
-     * To use with a doctrine_orm_callback filter type
+     * To use with a doctrine_orm_callback filter type.
      *
      * @param QueryBuilder $queryBuilder
-     * @param string $alias
-     * @param string $field
-     * @param string $value
+     * @param string       $alias
+     * @param string       $field
+     * @param string       $value
+     *
      * @return bool
      */
-    public static function translationFieldFilter($queryBuilder, $alias, $field, $value)
+    public static function translationFieldFilter(QueryBuilder $queryBuilder, $alias, $field, $value)
     {
         if (!$value['value']) {
             return;
@@ -97,18 +97,18 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
         }
 
         if ($aliasAlreadyExists === false) {
-            $queryBuilder->leftJoin($alias . '.translations', 't');
+            $queryBuilder->leftJoin($alias.'.translations', 't');
         }
 
         // search on translation OR on normal field
         $queryBuilder->andWhere($queryBuilder->expr()->orX(
             $queryBuilder->expr()->andX(
                 $queryBuilder->expr()->eq('t.field', $queryBuilder->expr()->literal($field)),
-                $queryBuilder->expr()->like('t.content', $queryBuilder->expr()->literal('%' . $value['value'] . '%'))
+                $queryBuilder->expr()->like('t.content', $queryBuilder->expr()->literal('%'.$value['value'].'%'))
             ),
             $queryBuilder->expr()->like(
                 sprintf('%s.%s', $alias, $field),
-                $queryBuilder->expr()->literal('%' . $value['value'] . '%')
+                $queryBuilder->expr()->literal('%'.$value['value'].'%')
             )
         ));
 

--- a/Admin/Extension/Gedmo/TranslatableAdminExtension.php
+++ b/Admin/Extension/Gedmo/TranslatableAdminExtension.php
@@ -13,8 +13,11 @@ namespace Sonata\TranslationBundle\Admin\Extension\Gedmo;
 
 use Gedmo\Translatable\TranslatableListener;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\TranslationBundle\Admin\Extension\AbstractTranslatableAdminExtension;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
+use Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
@@ -54,5 +57,61 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
             $this->getContainer($admin)->get('doctrine')->getManager()->refresh($object);
             $object->setLocale($this->getTranslatableLocale($admin));
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list')
+    {
+        $this->getTranslatableListener()->setTranslatableLocale($this->getTranslatableLocale($admin));
+        $this->getTranslatableListener()->setTranslationFallback('');
+    }
+
+    /**
+     * Search on normal field and on translation field
+     * To use with a doctrine_orm_callback filter type
+     *
+     * @param QueryBuilder $queryBuilder
+     * @param string $alias
+     * @param string $field
+     * @param string $value
+     * @return bool
+     */
+    public static function translationFieldFilter($queryBuilder, $alias, $field, $value)
+    {
+        if (!$value['value']) {
+            return;
+        }
+
+        // verify if the join is not already done
+        $aliasAlreadyExists = false;
+        $joinDqlParts = $queryBuilder->getDQLParts()['join'];
+        foreach ($joinDqlParts as $joins) {
+            foreach ($joins as $join) {
+                if ($join->getAlias() === 't') {
+                    $aliasAlreadyExists = true;
+                    break 2;
+                }
+            }
+        }
+
+        if ($aliasAlreadyExists === false) {
+            $queryBuilder->leftJoin($alias . '.translations', 't');
+        }
+
+        // search on translation OR on normal field
+        $queryBuilder->andWhere($queryBuilder->expr()->orX(
+            $queryBuilder->expr()->andX(
+                $queryBuilder->expr()->eq('t.field', $queryBuilder->expr()->literal($field)),
+                $queryBuilder->expr()->like('t.content', $queryBuilder->expr()->literal('%' . $value['value'] . '%'))
+            ),
+            $queryBuilder->expr()->like(
+                sprintf('%s.%s', $alias, $field),
+                $queryBuilder->expr()->literal('%' . $value['value'] . '%')
+            )
+        ));
+
+        return true;
     }
 }

--- a/Admin/Extension/Phpcr/TranslatableAdminExtension.php
+++ b/Admin/Extension/Phpcr/TranslatableAdminExtension.php
@@ -40,8 +40,21 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
         $unitOfWork         = $documentManager->getUnitOfWork();
 
         if ($this->getTranslatableChecker()->isTranslatable($object) && ($unitOfWork->getCurrentLocale($object) != $locale)) {
-            //@dbu : doesn't work - $documentManager->bindTranslation($object, $locale);
             $object = $this->getDocumentManager($admin)->findTranslation($admin->getClass(), $object->getId(), $locale);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preUpdate(AdminInterface $admin, $object)
+    {
+        $locale          = $this->getTranslatableLocale($admin);
+        $documentManager = $this->getDocumentManager($admin);
+        $unitOfWork      = $documentManager->getUnitOfWork();
+
+        if ($this->getTranslatableChecker()->isTranslatable($object) && ($unitOfWork->getCurrentLocale($object) != $locale)) {
+            $documentManager->bindTranslation($object, $locale);
         }
     }
 }

--- a/Admin/Extension/Phpcr/TranslatableAdminExtension.php
+++ b/Admin/Extension/Phpcr/TranslatableAdminExtension.php
@@ -35,26 +35,21 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
      */
     public function alterObject(AdminInterface $admin, $object)
     {
-        $locale             = $this->getTranslatableLocale($admin);
-        $documentManager    = $this->getDocumentManager($admin);
-        $unitOfWork         = $documentManager->getUnitOfWork();
-
-        if ($this->getTranslatableChecker()->isTranslatable($object) && ($unitOfWork->getCurrentLocale($object) != $locale)) {
-            $object = $this->getDocumentManager($admin)->findTranslation($admin->getClass(), $object->getId(), $locale);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function preUpdate(AdminInterface $admin, $object)
-    {
-        $locale          = $this->getTranslatableLocale($admin);
+        $locale = $this->getTranslatableLocale($admin);
         $documentManager = $this->getDocumentManager($admin);
-        $unitOfWork      = $documentManager->getUnitOfWork();
+        $unitOfWork = $documentManager->getUnitOfWork();
 
-        if ($this->getTranslatableChecker()->isTranslatable($object) && ($unitOfWork->getCurrentLocale($object) != $locale)) {
-            $documentManager->bindTranslation($object, $locale);
+        if (
+            $this->getTranslatableChecker()->isTranslatable($object)
+            && ($unitOfWork->getCurrentLocale($object) !== $locale)
+        ) {
+            $object = $this->getDocumentManager($admin)->findTranslation($admin->getClass(), $object->getId(), $locale);
+
+            // if the translation did not yet exists, the locale will be
+            // the fallback locale. This makes sure the new locale is set.
+            if ($unitOfWork->getCurrentLocale($object) !== $locale) {
+                $documentManager->bindTranslation($object, $locale);
+            }
         }
     }
 }

--- a/EventListener/LocaleSwitcherListener.php
+++ b/EventListener/LocaleSwitcherListener.php
@@ -28,6 +28,9 @@ class LocaleSwitcherListener
         if ($eventName == 'sonata.block.event.sonata.admin.show.top') {
             $settings['locale_switcher_route'] = 'show';
         }
+        if ($eventName == 'sonata.block.event.sonata.admin.list.table.top') {
+            $settings['locale_switcher_route'] = 'list';
+        }
 
         $block = new Block();
         $block->setSettings($settings);

--- a/Resources/config/listener.xml
+++ b/Resources/config/listener.xml
@@ -12,6 +12,7 @@
         <service id="sonata_translation.listener.locale_switcher" class="%sonata_translation.listener.locale_switcher.class%">
             <tag name="kernel.event_listener" event="sonata.block.event.sonata.admin.edit.form.top" method="onBlock"/>
             <tag name="kernel.event_listener" event="sonata.block.event.sonata.admin.show.top" method="onBlock"/>                       
+            <tag name="kernel.event_listener" event="sonata.block.event.sonata.admin.list.table.top" method="onBlock"/>
         </service>
     </services>
 

--- a/Resources/public/css/sonata-translation.css
+++ b/Resources/public/css/sonata-translation.css
@@ -2,7 +2,8 @@
  * SonataTranslation: adds translations to your forms
  */
 .sonata-bc .sonata-ba-form .locale_switcher,
-.sonata-bc .sonata-ba-show .locale_switcher {
+.sonata-bc .sonata-ba-show .locale_switcher,
+.sonata-bc .box-primary .locale_switcher {
   padding: 1px 0 0 0;
   text-align: right;
   margin-right: 15px;
@@ -10,66 +11,86 @@
   float: right;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a,
-.sonata-bc .sonata-ba-show .locale_switcher a {
+.sonata-bc .sonata-ba-show .locale_switcher a,
+.sonata-bc .box-primary .locale_switcher a {
   margin-right: 0;
   padding: 2px;
   opacity: 0.5;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a.active,
-.sonata-bc .sonata-ba-show .locale_switcher a.active {
+.sonata-bc .sonata-ba-show .locale_switcher a.active,
+.sonata-bc .box-primary .locale_switcher a.active {
   opacity: 1;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a:hover,
-.sonata-bc .sonata-ba-show .locale_switcher a:hover {
+.sonata-bc .sonata-ba-show .locale_switcher a:hover,
+.sonata-bc .box-primary .locale_switcher a:hover {
   opacity: 1;
 }
 .sonata-bc .sonata-ba-form label.wysiwyg.locale,
 .sonata-bc .sonata-ba-show label.wysiwyg.locale,
+.sonata-bc .box-primary label.wysiwyg.locale,
 .sonata-bc .sonata-ba-form label.checkbox.locale,
 .sonata-bc .sonata-ba-show label.checkbox.locale,
+.sonata-bc .box-primary label.checkbox.locale,
 .sonata-bc .sonata-ba-form input.locale,
 .sonata-bc .sonata-ba-show input.locale,
+.sonata-bc .box-primary input.locale,
 .sonata-bc .sonata-ba-form textarea.locale,
 .sonata-bc .sonata-ba-show textarea.locale,
+.sonata-bc .box-primary textarea.locale,
 .sonata-bc .sonata-ba-form select.locale,
 .sonata-bc .sonata-ba-show select.locale,
+.sonata-bc .box-primary select.locale,
 .sonata-bc .sonata-ba-form li.locale a,
-.sonata-bc .sonata-ba-show li.locale a {
+.sonata-bc .sonata-ba-show li.locale a,
+.sonata-bc .box-primary li.locale a {
   background-repeat: no-repeat;
 }
 .sonata-bc .sonata-ba-form input[type="text"].locale,
 .sonata-bc .sonata-ba-show input[type="text"].locale,
+.sonata-bc .box-primary input[type="text"].locale,
 .sonata-bc .sonata-ba-form select.locale,
-.sonata-bc .sonata-ba-show select.locale {
+.sonata-bc .sonata-ba-show select.locale,
+.sonata-bc .box-primary select.locale {
   padding-left: 35px !important;
   background-position: 5px center;
 }
 .sonata-bc .sonata-ba-form textarea.locale,
-.sonata-bc .sonata-ba-show textarea.locale {
+.sonata-bc .sonata-ba-show textarea.locale,
+.sonata-bc .box-primary textarea.locale {
   padding-left: 35px;
   background-position: 5px 5px;
 }
 .sonata-bc .sonata-ba-form label.wysiwyg.locale,
 .sonata-bc .sonata-ba-show label.wysiwyg.locale,
+.sonata-bc .box-primary label.wysiwyg.locale,
 .sonata-bc .sonata-ba-form label.checkbox.locale,
-.sonata-bc .sonata-ba-show label.checkbox.locale {
+.sonata-bc .sonata-ba-show label.checkbox.locale,
+.sonata-bc .box-primary label.checkbox.locale {
   padding-right: 35px;
   background-position: right bottom;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"],
-.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"] {
+.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"],
+.sonata-bc .box-primary .form-horizontal .controls input[type="checkbox"] {
   /*top: 5px;*/
   position: relative;
   width: 15px;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"].locale,
-.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"].locale {
+.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"].locale,
+.sonata-bc .box-primary .form-horizontal .controls input[type="checkbox"].locale {
   width: 65px;
   background-position: 0 center;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"]:before,
-.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"]:before {
+.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"]:before,
+.sonata-bc .box-primary .form-horizontal .controls input[type="checkbox"]:before {
   margin-right: 35px;
+}
+.sonata-bc .sonata-ba-show .locale_switcher {
+  margin-right: 15px;
 }
 .sonata-bc.locale_nl label.wysiwyg.locale,
 .sonata-bc.locale_nl label.checkbox.locale,

--- a/Resources/public/less/sonata-translation.less
+++ b/Resources/public/less/sonata-translation.less
@@ -3,7 +3,7 @@
  */
 .sonata-bc {
 
-    .sonata-ba-form, .sonata-ba-show {
+    .sonata-ba-form, .sonata-ba-show, .box-primary {
         .locale_switcher {
             padding: 1px 0 0 0;
             text-align: right;

--- a/Resources/views/Block/block_locale_switcher.html.twig
+++ b/Resources/views/Block/block_locale_switcher.html.twig
@@ -1,8 +1,15 @@
 {% set object = block_context.settings.object %}
 {% set admin  = block_context.settings.admin %}
 {% set locale_switcher_route = block_context.settings.locale_switcher_route %}
+{% set currentLocale = null %}
 
-{% if (object is translatable) %}
+{% if (admin.class is translatable) %}
+    {% for extension in admin.extensions %}
+        {% if(extension.translatableLocale is defined) %}
+            {% set currentLocale = extension.translatableLocale(admin) %}
+        {% endif %}
+    {% endfor %}
+
     <div class="locale_switcher">
         {% spaceless %}
             {% for locale in sonata_translation_locales %}
@@ -14,7 +21,7 @@
                     {% endif %}
                 {% endif %}
                 <a href="{{ admin.generateUrl(locale_switcher_route, {'id': admin.id(object), 'tl': locale}) }}" accesskey=""
-                   class=" {% if (object.locale == locale) %} active {% endif %}"
+                   class=" {% if (currentLocale == locale) %} active {% endif %}"
                    title="{{ 'admin.locale_switcher.tooltip' |trans([], 'SonataTranslationBundle') }}">
                     <img src="{{ asset('bundles/sonatatranslation/img/flags/' ~ locale ~ '.png')}}" />
                 </a>


### PR DESCRIPTION
In the configureQuery, with the translatable listener the locale is changed for Doctrine and data are translated on the list. 

translationFieldFilter is a callback method to use on doctrine_orm_callback filter to filter on field and on its translation.