### PR TITLE
make block settings work with older versions of sonata block bundle too

### DIFF
--- a/Block/LocaleSwitcherBlockService.php
+++ b/Block/LocaleSwitcherBlockService.php
@@ -15,12 +15,21 @@ use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */
 class LocaleSwitcherBlockService extends BaseBlockService
 {
+    /**
+     * @deprecated Will be removed when upgrading to SonataBlockBundle 3
+     */
+    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    {
+        $this->configureSettings($resolver);
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
fix #55
fix https://github.com/symfony-cmf/cmf-sandbox/issues/325

/cc @WouterJ i think this is the way to work with both versions