### PR TITLE
Fix wrong conflict rule for doctrine-orm-admin-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "conflict": {
         "knplabs/doctrine-behaviors": "<1.0 || >=2.0",
-        "sonata-project/doctrine-orm-admin-bundle": "<2.2 || >=3.0",
+        "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
         "sonata-project/doctrine-phpcr-admin-bundle": "<2.0 || >=3.0",
         "stof/doctrine-extensions-bundle": "<1.1 || >=2.0"
     },


### PR DESCRIPTION
### Changelog

```markdown
### Fixed
- Fix wrong conflict rule for `doctrine-orm-admin-bundle`
```

### Subject

Should begin at 3.0, not 2.0.

ping @alexndlm @greg0ire 