### PR TITLE
Remove doctrine phpcr admin conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
     "conflict": {
         "knplabs/doctrine-behaviors": "<1.0 || >=2.0",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
-        "sonata-project/doctrine-phpcr-admin-bundle": "<2.0 || >=3.0",
         "stof/doctrine-extensions-bundle": "<1.1 || >=2.0"
     },
     "autoload": {


### PR DESCRIPTION
As I already tried to explain, this bundle **does not depend on SonataDoctrinePhpcrOdmAdminBundle**. It makes absolutely no sense to set up conflict rules for this package.

A proof that this bundle doesn't use anything from that bundle: https://github.com/sonata-project/SonataTranslationBundle/search?utf8=%E2%9C%93&q=DoctrinePhpcr