### PR TITLE
Remove adapter bundles from the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,14 +31,13 @@
         "symfony/phpunit-bridge": "^2.7 || ^3.0"
     },
     "suggest": {
+        "doctrine/phpcr-odm": "if you translate odm documents",
         "knplabs/doctrine-behaviors": "if you translate orm entities with the knplabs behaviours",
-        "sonata-project/doctrine-orm-admin-bundle": "if you persist orm entities",
-        "sonata-project/doctrine-phpcr-admin-bundle": "if you persist phpcr-odm documents",
         "stof/doctrine-extensions-bundle": "if you translate orm entities with the gedmo extensions"
     },
     "conflict": {
+        "doctrine/phpcr-odm": ">=2.0",
         "knplabs/doctrine-behaviors": "<1.0 || >=2.0",
-        "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
         "stof/doctrine-extensions-bundle": "<1.1 || >=2.0"
     },
     "autoload": {


### PR DESCRIPTION
As requested in https://github.com/sonata-project/SonataTranslationBundle/pull/110#issuecomment-224930807 I also added a Doctrine PHPCR-ODM suggestion and conflict, because that's what's actually integrated in this bundle.

The conflict now is `>=2.0`, although multilang is such a fundamental feature of the PHPCR ODM that I don't expect much BC breaks in it. So the current code would probably work on 2.0 as well, but I guess you prefer to be very explicit about the supported versions.