### PR TITLE
fix missing locale annotation for Gedmo trait

### DIFF
--- a/Test/DoctrineOrmTestCase.php
+++ b/Test/DoctrineOrmTestCase.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TranslationBundle\Test;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\EventManager;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Tools\SchemaTool;
+
+/**
+ * Base test case contains common mock objects
+ * and functionality among all tests using
+ * ORM entity manager.
+ *
+ * @author Dariusz Markowicz <dmarkowicz77@gmail.com>
+ *
+ * Inspired by BaseTestCaseORM
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ */
+abstract class DoctrineOrmTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EntityManager
+     */
+    protected $em;
+
+    /**
+     * EntityManager mock object together with
+     * annotation mapping driver and pdo_sqlite
+     * database in memory.
+     *
+     * @param EventManager  $evm
+     * @param Configuration $config
+     *
+     * @return EntityManager
+     */
+    final protected function getMockSqliteEntityManager(EventManager $evm = null, Configuration $config = null)
+    {
+        $conn = array(
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
+        );
+
+        $em = EntityManager::create($conn, $config ?: $this->getMockAnnotatedConfig(), $evm ?: new EventManager());
+
+        $schema = array_map(function ($class) use ($em) {
+            return $em->getClassMetadata($class);
+        }, (array) $this->getUsedEntityFixtures());
+
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->dropSchema(array());
+        $schemaTool->createSchema($schema);
+
+        return $this->em = $em;
+    }
+
+    /**
+     * Creates default mapping driver.
+     *
+     * @return AnnotationDriver
+     */
+    final protected function getMetadataDriverImplementation()
+    {
+        return new AnnotationDriver(new AnnotationReader());
+    }
+
+    /**
+     * Get a list of used fixture classes.
+     *
+     * @return array
+     */
+    abstract protected function getUsedEntityFixtures();
+
+    /**
+     * Get annotation mapping configuration.
+     *
+     * @return Configuration
+     */
+    final protected function getMockAnnotatedConfig()
+    {
+        $config = new Configuration();
+        $config->setProxyDir(sys_get_temp_dir().'/sonata-translation-bundle');
+        $config->setProxyNamespace('Proxy');
+        $config->setMetadataDriverImpl($this->getMetadataDriverImplementation());
+
+        return $config;
+    }
+}

--- a/Tests/Fixtures/Traits/ORM/ArticlePersonalTranslatable.php
+++ b/Tests/Fixtures/Traits/ORM/ArticlePersonalTranslatable.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatableTrait;
+
+/**
+ * @Gedmo\TranslationEntity(class="Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslation")
+ * @ORM\Table(name="article")
+ * @ORM\Entity
+ */
+class ArticlePersonalTranslatable
+{
+    use PersonalTranslatableTrait;
+
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @Gedmo\Translatable
+     * @ORM\Column(length=128)
+     */
+    private $title;
+
+    /**
+     * @var ArrayCollection
+     *
+     * @ORM\OneToMany(
+     *     targetEntity="Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslation",
+     *     mappedBy="object",
+     *     cascade={"persist", "remove"}
+     * )
+     */
+    protected $translations;
+
+    public function __construct()
+    {
+        $this->translations = new ArrayCollection();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/Tests/Fixtures/Traits/ORM/ArticlePersonalTranslation.php
+++ b/Tests/Fixtures/Traits/ORM/ArticlePersonalTranslation.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;
+
+/**
+ * @ORM\Table(name="article_translation")
+ * @ORM\Entity
+ */
+class ArticlePersonalTranslation extends AbstractPersonalTranslation
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslatable", inversedBy="translations")
+     * @ORM\JoinColumn(name="object_id", referencedColumnName="id", onDelete="CASCADE")
+     */
+    protected $object;
+}

--- a/Tests/Traits/GedmoOrmTest.php
+++ b/Tests/Traits/GedmoOrmTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TranslationBundle\Tests\Traits;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Translatable\TranslatableListener;
+use Sonata\TranslationBundle\Test\DoctrineOrmTestCase;
+use Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslatable;
+use Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslation;
+
+class GedmoOrmTest extends DoctrineOrmTestCase
+{
+    const ARTICLE = 'Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslatable';
+    const TRANSLATION = 'Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslation';
+
+    /** @var TranslatableListener */
+    private $translatableListener;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (!class_exists('Doctrine\\ORM\\Version')) {
+            $this->markTestSkipped('Doctrine ORM is not available.');
+        }
+
+        $evm = new EventManager();
+        $this->translatableListener = new TranslatableListener();
+        $this->translatableListener->setTranslatableLocale('en');
+        $this->translatableListener->setDefaultLocale('en');
+        $evm->addEventSubscriber($this->translatableListener);
+
+        $this->getMockSqliteEntityManager($evm);
+    }
+
+    public function testPersonalTranslatableEntity()
+    {
+        $article = new ArticlePersonalTranslatable();
+        $article->setTitle('en');
+
+        $this->em->persist($article);
+        $this->em->flush();
+
+        $this->translatableListener->setTranslatableLocale('de');
+        $article->setTitle('de');
+
+        $ltTranslation = new ArticlePersonalTranslation();
+        $ltTranslation
+            ->setField('title')
+            ->setContent('lt')
+            ->setObject($article)
+            ->setLocale('lt')
+        ;
+        $this->em->persist($ltTranslation);
+        $this->em->persist($article);
+        $this->em->flush();
+
+        // Tests if Gedmo\Locale annotation exists
+        $article->setLocale('pl');
+        $article->setTitle('pl');
+        $this->em->persist($article);
+        $this->em->flush();
+
+        $this->em->clear();
+
+        $article = $this->em->find(self::ARTICLE, array('id' => 1));
+        $translations = $article->getTranslations();
+        $this->assertCount(3, $translations);
+    }
+
+    protected function getUsedEntityFixtures()
+    {
+        return array(
+            self::ARTICLE,
+            self::TRANSLATION,
+        );
+    }
+}

--- a/Traits/Gedmo/PersonalTranslatableTrait.php
+++ b/Traits/Gedmo/PersonalTranslatableTrait.php
@@ -12,7 +12,6 @@
 namespace Sonata\TranslationBundle\Traits\Gedmo;
 
 use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;
-use Sonata\TranslationBundle\Traits\TranslatableTrait;
 
 /**
  * If you don't want to use trait, you can extend AbstractPersonalTranslatable instead.

--- a/Traits/Gedmo/TranslatableTrait.php
+++ b/Traits/Gedmo/TranslatableTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TranslationBundle\Traits\Gedmo;
+
+/**
+ * If you don't want to use trait, you can extend AbstractTranslatable instead.
+ *
+ * @author Nicolas Bastien <nbastien.pro@gmail.com>
+ */
+trait TranslatableTrait
+{
+    /**
+     * @Gedmo\Locale
+     * Used locale to override Translation listener`s locale
+     * this is not a mapped field of entity metadata, just a simple property
+     *
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * @param string $locale
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is a bug fix for 2.x

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- fix missing locale annotation for Gedmo trait

```

## Subject
`\Traits\Gedmo\PersonalTranslatableTrait` should use new `\Traits\Gedmo\TranslatableTrait` with `@Gedmo\Locale` annotation (same as `\Model\Gedmo\AbstractTranslatable` class). This fix `$entity->setLocale('XX')` mechanic if entity use traits.
<!-- Describe your Pull Request content here -->

