### PR TITLE
translation-bundle version-neutral composer cmd

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -9,7 +9,7 @@ following command to download the latest stable version of this bundle:
 
 .. code-block:: bash
 
-    $ composer require sonata-project/translation-bundle "~1"
+    $ composer require sonata-project/translation-bundle
 
 This command requires you to have Composer installed globally, as explained
 in the `installation chapter`_ of the Composer documentation.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
## Subject

<!-- Describe your Pull Request content here -->

Removing Composer version in order to force it choose latest version. according to [issuecomment-239639169](https://github.com/sonata-project/SonataTranslationBundle/pull/120#issuecomment-239639169) by @dbu