### PR TITLE
Deprecate old trait names

### DIFF
--- a/Checker/TranslatableChecker.php
+++ b/Checker/TranslatableChecker.php
@@ -72,11 +72,16 @@ class TranslatableChecker
         }
 
         if (function_exists('class_uses')) {
+            // NEXT_MAJOR: remove Translateable and PersonalTrait
+            $translateTraits = array(
+                'Sonata\TranslationBundle\Traits\Translatable',
+                'Sonata\TranslationBundle\Traits\TranslatableTrait',
+                'Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatable',
+                'Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatableTrait',
+            );
+
             $traits = class_uses($object);
-            if (in_array('Sonata\TranslationBundle\Traits\Translatable', $traits)) {
-                return true;
-            }
-            if (in_array('Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatable', $traits)) {
+            if (count(array_intersect($translateTraits, $traits)) > 0) {
                 return true;
             }
         }

--- a/Resources/doc/reference/orm.rst
+++ b/Resources/doc/reference/orm.rst
@@ -97,8 +97,8 @@ Please check the docs in the `Gedmo translatable documentation`_.
 
     If you prefer to use `traits`, we provide :
 
-    * `Sonata\TranslationBundle\Traits\Translatable`
-    * `Sonata\TranslationBundle\Traits\PersonalTranslatable`
+    * `Sonata\TranslationBundle\Traits\TranslatableTrait`
+    * `Sonata\TranslationBundle\Traits\PersonalTranslatableTrait`
 
 2.2 Example using Personal Translation with Traits
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ Please check the docs in the `Gedmo translatable documentation`_.
     use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
     use Doctrine\ORM\Mapping as ORM;
     use Doctrine\Common\Collections\ArrayCollection;
-    use Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatable;
+    use Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatableTrait;
 
     /**
      * @author Nicolas Bastien <nbastien@prestaconcept.net>
@@ -125,7 +125,7 @@ Please check the docs in the `Gedmo translatable documentation`_.
      */
     class FAQCategory implements TranslatableInterface
     {
-        use PersonalTranslatable;
+        use PersonalTranslatableTrait;
 
         /**
          * @ORM\Id

--- a/Tests/Checker/TranslatableCheckerTest.php
+++ b/Tests/Checker/TranslatableCheckerTest.php
@@ -14,7 +14,7 @@ namespace Sonata\TranslationBundle\Tests\Checker;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\Model\AbstractTranslatable;
 use Sonata\TranslationBundle\Model\TranslatableInterface;
-use Sonata\TranslationBundle\Traits\Translatable;
+use Sonata\TranslationBundle\Traits\TranslatableTrait;
 
 class ModelTranslatable extends AbstractTranslatable implements TranslatableInterface
 {
@@ -26,7 +26,7 @@ class ModelCustomTranslatable
 
 class ModelUsingTraitTranslatable
 {
-    use Translatable;
+    use TranslatableTrait;
 }
 
 /**

--- a/Tests/Checker/TranslatableCheckerTest.php
+++ b/Tests/Checker/TranslatableCheckerTest.php
@@ -12,22 +12,9 @@
 namespace Sonata\TranslationBundle\Tests\Checker;
 
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
-use Sonata\TranslationBundle\Model\AbstractTranslatable;
-use Sonata\TranslationBundle\Model\TranslatableInterface;
-use Sonata\TranslationBundle\Traits\TranslatableTrait;
-
-class ModelTranslatable extends AbstractTranslatable implements TranslatableInterface
-{
-}
-
-class ModelCustomTranslatable
-{
-}
-
-class ModelUsingTraitTranslatable
-{
-    use TranslatableTrait;
-}
+use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelCustomTranslatable;
+use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelTranslatable;
+use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelUsingTraitTranslatable;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
@@ -64,7 +51,7 @@ class TranslatableCheckerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($translatableChecker->isTranslatable($object));
 
         $translatableChecker->setSupportedModels(array(
-            'Sonata\TranslationBundle\Tests\Checker\ModelCustomTranslatable',
+            'Sonata\TranslationBundle\Tests\Fixtures\Model\ModelCustomTranslatable',
         ));
 
         $this->assertTrue($translatableChecker->isTranslatable($object));

--- a/Tests/Fixtures/Model/ModelCustomTranslatable.php
+++ b/Tests/Fixtures/Model/ModelCustomTranslatable.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Model;
+
+class ModelCustomTranslatable
+{
+}

--- a/Tests/Fixtures/Model/ModelPersonalTranslatable.php
+++ b/Tests/Fixtures/Model/ModelPersonalTranslatable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Model;
+
+use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslatable;
+use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
+
+class ModelPersonalTranslatable extends AbstractPersonalTranslatable implements TranslatableInterface
+{
+}

--- a/Tests/Fixtures/Model/ModelPersonalTranslation.php
+++ b/Tests/Fixtures/Model/ModelPersonalTranslation.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Model;
+
+use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;
+
+class ModelPersonalTranslation extends AbstractPersonalTranslation
+{
+}

--- a/Tests/Fixtures/Model/ModelTranslatable.php
+++ b/Tests/Fixtures/Model/ModelTranslatable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Model;
+
+use Sonata\TranslationBundle\Model\Gedmo\AbstractTranslatable;
+use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
+
+class ModelTranslatable extends AbstractTranslatable implements TranslatableInterface
+{
+}
+

--- a/Tests/Fixtures/Model/ModelUsingTraitTranslatable.php
+++ b/Tests/Fixtures/Model/ModelUsingTraitTranslatable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Model;
+
+use Sonata\TranslationBundle\Traits\TranslatableTrait;
+
+class ModelUsingTraitTranslatable
+{
+    use TranslatableTrait;
+}

--- a/Tests/Fixtures/Traits/ModelPersonalTranslatable.php
+++ b/Tests/Fixtures/Traits/ModelPersonalTranslatable.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Traits;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
+use Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatableTrait;
+
+class ModelPersonalTranslatable implements TranslatableInterface
+{
+    use PersonalTranslatableTrait;
+
+    /**
+     * @var ArrayCollection
+     */
+    protected $translations;
+
+    public function __construct()
+    {
+        $this->translations = new ArrayCollection();
+    }
+}

--- a/Tests/Fixtures/Traits/ModelPersonalTranslation.php
+++ b/Tests/Fixtures/Traits/ModelPersonalTranslation.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Traits;
+
+use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;
+
+class ModelPersonalTranslation extends AbstractPersonalTranslation
+{
+}

--- a/Tests/Fixtures/Traits/ModelTranslatable.php
+++ b/Tests/Fixtures/Traits/ModelTranslatable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Traits;
+
+use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
+use Sonata\TranslationBundle\Traits\TranslatableTrait;
+
+class ModelTranslatable implements TranslatableInterface
+{
+    use TranslatableTrait;
+}

--- a/Tests/Model/GedmoTest.php
+++ b/Tests/Model/GedmoTest.php
@@ -11,22 +11,10 @@
 
 namespace Sonata\TranslationBundle\Tests\Model;
 
-use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslatable;
-use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;
-use Sonata\TranslationBundle\Model\Gedmo\AbstractTranslatable;
 use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
-
-class ModelTranslatable extends AbstractTranslatable implements TranslatableInterface
-{
-}
-
-class ModelPersonalTranslatable extends AbstractPersonalTranslatable implements TranslatableInterface
-{
-}
-
-class ModelPersonalTranslation extends AbstractPersonalTranslation
-{
-}
+use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelPersonalTranslatable;
+use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelPersonalTranslation;
+use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelTranslatable;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
@@ -42,7 +30,7 @@ class GedmoTest extends \PHPUnit_Framework_TestCase
         $model->setLocale('fr');
 
         $this->assertSame('fr', $model->getLocale());
-        $this->assertTrue($model instanceof \Sonata\TranslationBundle\Model\TranslatableInterface);
+        $this->assertTrue($model instanceof TranslatableInterface);
     }
 
     /**
@@ -54,7 +42,7 @@ class GedmoTest extends \PHPUnit_Framework_TestCase
         $model->setLocale('fr');
 
         $this->assertSame('fr', $model->getLocale());
-        $this->assertTrue($model instanceof \Sonata\TranslationBundle\Model\TranslatableInterface);
+        $this->assertTrue($model instanceof TranslatableInterface);
 
         $model->addTranslation(new ModelPersonalTranslation('en', 'title', 'Title en'));
         $model->addTranslation(new ModelPersonalTranslation('it', 'title', 'Title it'));

--- a/Tests/Traits/GedmoTest.php
+++ b/Tests/Traits/GedmoTest.php
@@ -14,17 +14,17 @@ namespace Sonata\TranslationBundle\Tests\Traits;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;
 use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
-use Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatable;
-use Sonata\TranslationBundle\Traits\Translatable;
+use Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatableTrait;
+use Sonata\TranslationBundle\Traits\TranslatableTrait;
 
 class ModelTranslatable implements TranslatableInterface
 {
-    use Translatable;
+    use TranslatableTrait;
 }
 
 class ModelPersonalTranslatable implements TranslatableInterface
 {
-    use PersonalTranslatable;
+    use PersonalTranslatableTrait;
 
     /**
      * @var ArrayCollection
@@ -47,7 +47,7 @@ class ModelPersonalTranslation extends AbstractPersonalTranslation
 class GedmoTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @test Translatable
+     * @test TranslatableTrait
      */
     public function testTranslatableModel()
     {
@@ -59,7 +59,7 @@ class GedmoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @test PersonalTranslatable
+     * @test PersonalTranslatableTrait
      */
     public function testPersonalTranslatableModel()
     {

--- a/Tests/Traits/GedmoTest.php
+++ b/Tests/Traits/GedmoTest.php
@@ -11,35 +11,11 @@
 
 namespace Sonata\TranslationBundle\Tests\Traits;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;
-use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
+use Sonata\TranslationBundle\Tests\Fixtures\Traits\ModelPersonalTranslatable;
+use Sonata\TranslationBundle\Tests\Fixtures\Traits\ModelPersonalTranslation;
+use Sonata\TranslationBundle\Tests\Fixtures\Traits\ModelTranslatable;
 use Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatableTrait;
 use Sonata\TranslationBundle\Traits\TranslatableTrait;
-
-class ModelTranslatable implements TranslatableInterface
-{
-    use TranslatableTrait;
-}
-
-class ModelPersonalTranslatable implements TranslatableInterface
-{
-    use PersonalTranslatableTrait;
-
-    /**
-     * @var ArrayCollection
-     */
-    protected $translations;
-
-    public function __construct()
-    {
-        $this->translations = new ArrayCollection();
-    }
-}
-
-class ModelPersonalTranslation extends AbstractPersonalTranslation
-{
-}
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>

--- a/Traits/Gedmo/PersonalTranslatable.php
+++ b/Traits/Gedmo/PersonalTranslatable.php
@@ -11,55 +11,20 @@
 
 namespace Sonata\TranslationBundle\Traits\Gedmo;
 
-use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;
-use Sonata\TranslationBundle\Traits\Translatable;
+@trigger_error(
+    'The '.__NAMESPACE__.'\PersonalTranslatable class is deprecated since version 2.x and will be removed in 3.0.'.
+    'Use the '.__NAMESPACE__.'\PersonalTranslatableTrait class instead.',
+    E_USER_DEPRECATED
+);
 
 /**
  * If you don't want to use trait, you can extend AbstractPersonalTranslatable instead.
  *
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
+ *
+ * @deprecated since version 2.x and will be removed in 3.0
  */
 trait PersonalTranslatable
 {
-    use Translatable;
-
-    /**
-     * @return ArrayCollection|AbstractPersonalTranslation[]
-     */
-    public function getTranslations()
-    {
-        return $this->translations;
-    }
-
-    /**
-     * @param $field
-     * @param $locale
-     *
-     * @return null|string
-     */
-    public function getTranslation($field, $locale)
-    {
-        foreach ($this->getTranslations() as $translation) {
-            if (strcmp($translation->getField(), $field) === 0 && strcmp($translation->getLocale(), $locale) === 0) {
-                return $translation->getContent();
-            }
-        }
-
-        return;
-    }
-
-    /**
-     * @param AbstractPersonalTranslation $translation
-     *
-     * @return $this
-     */
-    public function addTranslation(AbstractPersonalTranslation $translation)
-    {
-        if (!$this->translations->contains($translation)) {
-            $translation->setObject($this);
-            $this->translations->add($translation);
-        }
-
-        return $this;
-    }
+    use PersonalTranslatableTrait;
 }

--- a/Traits/Gedmo/PersonalTranslatableTrait.php
+++ b/Traits/Gedmo/PersonalTranslatableTrait.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TranslationBundle\Traits\Gedmo;
+
+use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;
+use Sonata\TranslationBundle\Traits\TranslatableTrait;
+
+/**
+ * If you don't want to use trait, you can extend AbstractPersonalTranslatable instead.
+ *
+ * @author Nicolas Bastien <nbastien.pro@gmail.com>
+ */
+trait PersonalTranslatableTrait
+{
+    use TranslatableTrait;
+
+    /**
+     * @return ArrayCollection|AbstractPersonalTranslation[]
+     */
+    public function getTranslations()
+    {
+        return $this->translations;
+    }
+
+    /**
+     * @param $field
+     * @param $locale
+     *
+     * @return null|string
+     */
+    public function getTranslation($field, $locale)
+    {
+        foreach ($this->getTranslations() as $translation) {
+            if (strcmp($translation->getField(), $field) === 0 && strcmp($translation->getLocale(), $locale) === 0) {
+                return $translation->getContent();
+            }
+        }
+
+        return;
+    }
+
+    /**
+     * @param AbstractPersonalTranslation $translation
+     *
+     * @return $this
+     */
+    public function addTranslation(AbstractPersonalTranslation $translation)
+    {
+        if (!$this->translations->contains($translation)) {
+            $translation->setObject($this);
+            $this->translations->add($translation);
+        }
+
+        return $this;
+    }
+}

--- a/Traits/TranslatableTrait.php
+++ b/Traits/TranslatableTrait.php
@@ -11,20 +11,31 @@
 
 namespace Sonata\TranslationBundle\Traits;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\Translatable class is deprecated since version 2.x and will be removed in 3.0.'.
-    'Use the '.__NAMESPACE__.'\TranslatableTrait class instead.',
-    E_USER_DEPRECATED
-);
-
 /**
  * If you don't want to use trait, you can extend AbstractTranslatable instead.
  *
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
- *
- * @deprecated since version 2.x and will be removed in 3.0
  */
-trait Translatable
+trait TranslatableTrait
 {
-    use TranslatableTrait;
+    /**
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * @param string $locale
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #123

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- deprecate `Translatable` in favor of `TranslatableTrait`
- deprecate `PersonalTranslatable` in favor of `PersonalTranslatableTrait`
```

## Subject

According to [symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html#naming-conventions), all traits should have a `*Trait` suffix.

