### PR TITLE
fix tests namespace

### DIFF
--- a/Tests/Checker/TranslatableCheckerTest.php
+++ b/Tests/Checker/TranslatableCheckerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\AdminBundle\Tests\Checker;
+namespace Sonata\TranslationBundle\Tests\Checker;
 
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\Model\AbstractTranslatable;
@@ -64,7 +64,7 @@ class TranslatableCheckerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($translatableChecker->isTranslatable($object));
 
         $translatableChecker->setSupportedModels(array(
-            'Sonata\AdminBundle\Tests\Checker\ModelCustomTranslatable',
+            'Sonata\TranslationBundle\Tests\Checker\ModelCustomTranslatable',
         ));
 
         $this->assertTrue($translatableChecker->isTranslatable($object));

--- a/Tests/Model/GedmoTest.php
+++ b/Tests/Model/GedmoTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\AdminBundle\Tests\Model;
+namespace Sonata\TranslationBundle\Tests\Model;
 
 use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslatable;
 use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;

--- a/Tests/Resources/XliffTest.php
+++ b/Tests/Resources/XliffTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\AdminBundle\Tests\Resources;
+namespace Sonata\TranslationBundle\Tests\Resources;
 
 use Sonata\CoreBundle\Test\XliffValidatorTestCase;
 

--- a/Tests/Traits/GedmoTest.php
+++ b/Tests/Traits/GedmoTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\AdminBundle\Tests\Traits;
+namespace Sonata\TranslationBundle\Tests\Traits;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is backwards compatible minor fix

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
fix tests namespace

```
## Subject

<!-- Describe your Pull Request content here -->
Changed namespace for test classes from `Sonata\AdminBundle\Tests` to `Sonata\TranslationBundle\Tests`


