### PR TITLE
Fixed test namespace

### DIFF
--- a/Tests/Checker/TranslatableCheckerTest.php
+++ b/Tests/Checker/TranslatableCheckerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\AdminBundle\Tests\Checker;
+namespace Sonata\TranslationBundle\Tests\Checker;
 
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\Model\AbstractTranslatable;

--- a/Tests/Model/GedmoTest.php
+++ b/Tests/Model/GedmoTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\AdminBundle\Tests\Model;
+namespace Sonata\TranslationBundle\Tests\Model;
 
 use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslatable;
 use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;

--- a/Tests/Resources/XliffTest.php
+++ b/Tests/Resources/XliffTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\AdminBundle\Tests\Resources;
+namespace Sonata\TranslationBundle\Tests\Resources;
 
 use Sonata\CoreBundle\Test\XliffValidatorTestCase;
 

--- a/Tests/Traits/GedmoTest.php
+++ b/Tests/Traits/GedmoTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\AdminBundle\Tests\Traits;
+namespace Sonata\TranslationBundle\Tests\Traits;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is pedantic.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

Fixed wrong namespace in test classes.

