### PR TITLE
Display flags for locales with country code

### DIFF
--- a/Resources/views/Block/block_locale_switcher.html.twig
+++ b/Resources/views/Block/block_locale_switcher.html.twig
@@ -21,7 +21,7 @@
                    accesskey=""
                    class=" {% if (object.locale == locale) %} active {% endif %}"
                    title="{{ 'admin.locale_switcher.tooltip' |trans([], 'SonataTranslationBundle') }}">
-                    <img src="{{ asset('bundles/sonatatranslation/img/flags/' ~ locale ~ '.png')}}" />
+                    <img src="{{ asset('bundles/sonatatranslation/img/flags/' ~ locale[-2:2]|lower ~ '.png')}}" />
                 </a>
             {% endfor %}
         {% endspaceless %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is fix for 2.x.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Display flags for locales with country code
```

## Subject
Locale Switcher Block does not display flag icons for locales with country codes, i.e.: pt_BR, en_US. There are no such images, so user see 404 instead. This solution just take last 2 characters from locale and display proper icon. It will be:
`pt.png` for `pt`
`br.png` for `pt_BR`
`us.png` for `en_US`
etc.
<!-- Describe your Pull Request content here -->

