### PR TITLE
Added missing upgrade notes for traits

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -6,3 +6,11 @@ UPGRADE 2.x
 All files under the ``Tests`` directory are now correctly handled as internal test classes. 
 You can't extend them anymore, because they are only loaded when running internal tests. 
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).
+
+## Deprecated traits
+
+The `Sonata\TranslationBundle\Traits\Translatable` class is deprecated. 
+Use `Sonata\TranslationBundle\Traits\TranslatableTrait` instead.
+
+The `Sonata\TranslationBundle\Traits\PersonalTranslatable` class is deprecated. 
+Use `Sonata\TranslationBundle\Traits\PersonalTranslatableTrait` instead.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is just a doc update.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #124

## Subject

Adds the missing `UPGRADE-2.x` docs for trait deprecation.