### PR TITLE
allow to switch content language on list and filter by language (continued)

### DIFF
--- a/Admin/Extension/Gedmo/TranslatableAdminExtension.php
+++ b/Admin/Extension/Gedmo/TranslatableAdminExtension.php
@@ -14,7 +14,6 @@ namespace Sonata\TranslationBundle\Admin\Extension\Gedmo;
 use Gedmo\Translatable\TranslatableListener;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\TranslationBundle\Admin\Extension\AbstractTranslatableAdminExtension;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 
@@ -56,53 +55,6 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
     {
         $this->getTranslatableListener($admin)->setTranslatableLocale($this->getTranslatableLocale($admin));
         $this->getTranslatableListener($admin)->setTranslationFallback(false);
-    }
-
-    /**
-     * Search on normal field and on translated field, use with a
-     * doctrine_orm_callback filter type.
-     *
-     * @param ProxyQuery $queryBuilder
-     * @param string     $alias
-     * @param string     $field
-     * @param string     $value
-     *
-     * @return bool|null
-     */
-    public static function translationFieldFilter(ProxyQuery $queryBuilder, $alias, $field, $value)
-    {
-        if (!$value['value']) {
-            return;
-        }
-
-        // verify if the join is not already done
-        $aliasAlreadyExists = false;
-        foreach ($queryBuilder->getDQLParts()['join'] as $joins) {
-            foreach ($joins as $join) {
-                if ($join->getAlias() === 't') {
-                    $aliasAlreadyExists = true;
-                    break 2;
-                }
-            }
-        }
-
-        if (!$aliasAlreadyExists) {
-            $queryBuilder->leftJoin($alias.'.translations', 't');
-        }
-
-        // search on translation OR on normal field
-        $queryBuilder->andWhere($queryBuilder->expr()->orX(
-            $queryBuilder->expr()->andX(
-                $queryBuilder->expr()->eq('t.field', $queryBuilder->expr()->literal($field)),
-                $queryBuilder->expr()->like('t.content', $queryBuilder->expr()->literal('%'.$value['value'].'%'))
-            ),
-            $queryBuilder->expr()->like(
-                sprintf('%s.%s', $alias, $field),
-                $queryBuilder->expr()->literal('%'.$value['value'].'%')
-            )
-        ));
-
-        return true;
     }
 
     /**

--- a/EventListener/LocaleSwitcherListener.php
+++ b/EventListener/LocaleSwitcherListener.php
@@ -28,6 +28,9 @@ class LocaleSwitcherListener
         if ($eventName == 'sonata.block.event.sonata.admin.show.top') {
             $settings['locale_switcher_route'] = 'show';
         }
+        if ($eventName == 'sonata.block.event.sonata.admin.list.table.top') {
+            $settings['locale_switcher_route'] = 'list';
+        }
 
         $block = new Block();
         $block->setSettings($settings);

--- a/Filter/TranslationFieldFilter.php
+++ b/Filter/TranslationFieldFilter.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TranslationBundle\Filter;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\DoctrineORMAdminBundle\Filter\Filter;
+
+final class TranslationFieldFilter extends Filter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
+    {
+        if (!$data || !is_array($data) || !array_key_exists('value', $data)) {
+            return;
+        }
+
+        $data['value'] = trim($data['value']);
+
+        if (strlen($data['value']) == 0) {
+            return;
+        }
+
+        $joinAlias = 'tff';
+
+        // verify if the join is not already done
+        $aliasAlreadyExists = false;
+        foreach ($queryBuilder->getDQLParts()['join'] as $joins) {
+            foreach ($joins as $join) {
+                if ($join->getAlias() === $joinAlias) {
+                    $aliasAlreadyExists = true;
+                    break 2;
+                }
+            }
+        }
+
+        if (!$aliasAlreadyExists) {
+            $queryBuilder->leftJoin($alias.'.translations', $joinAlias);
+        }
+
+        // search on translation OR on normal field
+        $queryBuilder->andWhere($queryBuilder->expr()->orX(
+            $queryBuilder->expr()->andX(
+                $queryBuilder->expr()->eq($joinAlias.'.field', $queryBuilder->expr()->literal($field)),
+                $queryBuilder->expr()->like(
+                    $joinAlias.'.content',
+                    $queryBuilder->expr()->literal('%'.$data['value'].'%')
+                )
+            ),
+            $queryBuilder->expr()->like(
+                sprintf('%s.%s', $alias, $field),
+                $queryBuilder->expr()->literal('%'.$data['value'].'%')
+            )
+        ));
+
+        $this->active = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOptions()
+    {
+        return array(
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                : 'text', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+                : 'hidden', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'operator_options' => array(),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRenderSettings()
+    {
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
+            : 'sonata_type_filter_default';
+
+        return array($type, array(
+            'field_type' => $this->getFieldType(),
+            'field_options' => $this->getFieldOptions(),
+            'operator_type' => $this->getOption('operator_type'),
+            'operator_options' => $this->getOption('operator_options'),
+            'label' => $this->getLabel(),
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function association(ProxyQueryInterface $queryBuilder, $data)
+    {
+        $alias = $queryBuilder->entityJoin($this->getParentAssociationMappings());
+
+        return array($this->getOption('alias', $alias), $this->getFieldName());
+    }
+}

--- a/Resources/config/listener.xml
+++ b/Resources/config/listener.xml
@@ -7,6 +7,7 @@
         <service id="sonata_translation.listener.locale_switcher" class="%sonata_translation.listener.locale_switcher.class%">
             <tag name="kernel.event_listener" event="sonata.block.event.sonata.admin.edit.form.top" method="onBlock"/>
             <tag name="kernel.event_listener" event="sonata.block.event.sonata.admin.show.top" method="onBlock"/>
+            <tag name="kernel.event_listener" event="sonata.block.event.sonata.admin.list.table.top" method="onBlock"/>
         </service>
     </services>
 </container>

--- a/Resources/config/service.xml
+++ b/Resources/config/service.xml
@@ -5,5 +5,8 @@
     </parameters>
     <services>
         <service id="sonata_translation.checker.translatable" class="%sonata_translation.checker.translatable.class%"/>
+        <service id="sonata_translation.filter.type.translation_field" class="Sonata\TranslationBundle\Filter\TranslationFieldFilter">
+            <tag name="sonata.admin.filter.type" alias="doctrine_orm_translation_field"/>
+        </service>
     </services>
 </container>

--- a/Resources/doc/reference/orm.rst
+++ b/Resources/doc/reference/orm.rst
@@ -173,6 +173,44 @@ you have to make a translation class to handle it.
         protected $object;
     }
 
+4. Configure search filter
+--------------------------
+
+**This step is optional**, but you can use the ``translationFieldFilter`` callback method on ``doctrine_orm_callback``
+filter to search on fields and on their translations.
+
+4.1 Example for configure search filter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: php
+
+    <?php
+
+    namespace AppBundle\Admin;
+
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Datagrid\DatagridMapper;
+    use Sonata\AdminBundle\Datagrid\ListMapper;
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Show\ShowMapper;
+
+    class FAQCategoryAdmin extends AbstractAdmin
+    {
+        /**
+         * @param DatagridMapper $datagridMapper
+         */
+        protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+        {
+            $datagridMapper
+                // ...
+                ->add('title', 'doctrine_orm_callback', array(
+                    'callback' => array(
+                        'Sonata\TranslationBundle\Admin\Extension\Gedmo\TranslatableAdminExtension',
+                        'translationFieldFilter',
+                    ),
+                ));
+        }
+
 B. Using KnpLabs Doctrine Behaviours
 ------------------------------------
 

--- a/Resources/doc/reference/orm.rst
+++ b/Resources/doc/reference/orm.rst
@@ -176,7 +176,7 @@ you have to make a translation class to handle it.
 4. Configure search filter
 --------------------------
 
-**This step is optional**, but you can use the ``translationFieldFilter`` callback method on ``doctrine_orm_callback``
+**This step is optional**, but you can use the ``doctrine_orm_translation_field``
 filter to search on fields and on their translations.
 
 4.1 Example for configure search filter
@@ -193,6 +193,7 @@ filter to search on fields and on their translations.
     use Sonata\AdminBundle\Datagrid\ListMapper;
     use Sonata\AdminBundle\Form\FormMapper;
     use Sonata\AdminBundle\Show\ShowMapper;
+    use Sonata\TranslationBundle\Filter\TranslationFieldFilter;
 
     class FAQCategoryAdmin extends AbstractAdmin
     {
@@ -203,12 +204,7 @@ filter to search on fields and on their translations.
         {
             $datagridMapper
                 // ...
-                ->add('title', 'doctrine_orm_callback', array(
-                    'callback' => array(
-                        'Sonata\TranslationBundle\Admin\Extension\Gedmo\TranslatableAdminExtension',
-                        'translationFieldFilter',
-                    ),
-                ));
+                ->add('title', TranslationFieldFilter::class); // or 'doctrine_orm_translation_field'
         }
 
 B. Using KnpLabs Doctrine Behaviours

--- a/Resources/public/css/sonata-translation.css
+++ b/Resources/public/css/sonata-translation.css
@@ -2,7 +2,8 @@
  * SonataTranslation: adds translations to your forms
  */
 .sonata-bc .sonata-ba-form .locale_switcher,
-.sonata-bc .sonata-ba-show .locale_switcher {
+.sonata-bc .sonata-ba-show .locale_switcher,
+.sonata-bc .box-primary .locale_switcher {
   padding: 1px 0 0 0;
   text-align: right;
   margin-right: 15px;
@@ -10,66 +11,86 @@
   float: right;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a,
-.sonata-bc .sonata-ba-show .locale_switcher a {
+.sonata-bc .sonata-ba-show .locale_switcher a,
+.sonata-bc .box-primary .locale_switcher a {
   margin-right: 0;
   padding: 2px;
   opacity: 0.5;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a.active,
-.sonata-bc .sonata-ba-show .locale_switcher a.active {
+.sonata-bc .sonata-ba-show .locale_switcher a.active,
+.sonata-bc .box-primary .locale_switcher a.active {
   opacity: 1;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a:hover,
-.sonata-bc .sonata-ba-show .locale_switcher a:hover {
+.sonata-bc .sonata-ba-show .locale_switcher a:hover,
+.sonata-bc .box-primary .locale_switcher a:hover {
   opacity: 1;
 }
 .sonata-bc .sonata-ba-form label.wysiwyg.locale,
 .sonata-bc .sonata-ba-show label.wysiwyg.locale,
+.sonata-bc .box-primary label.wysiwyg.locale,
 .sonata-bc .sonata-ba-form label.checkbox.locale,
 .sonata-bc .sonata-ba-show label.checkbox.locale,
+.sonata-bc .box-primary label.checkbox.locale,
 .sonata-bc .sonata-ba-form input.locale,
 .sonata-bc .sonata-ba-show input.locale,
+.sonata-bc .box-primary input.locale,
 .sonata-bc .sonata-ba-form textarea.locale,
 .sonata-bc .sonata-ba-show textarea.locale,
+.sonata-bc .box-primary textarea.locale,
 .sonata-bc .sonata-ba-form select.locale,
 .sonata-bc .sonata-ba-show select.locale,
+.sonata-bc .box-primary select.locale,
 .sonata-bc .sonata-ba-form li.locale a,
-.sonata-bc .sonata-ba-show li.locale a {
+.sonata-bc .sonata-ba-show li.locale a,
+.sonata-bc .box-primary li.locale a {
   background-repeat: no-repeat;
 }
 .sonata-bc .sonata-ba-form input[type="text"].locale,
 .sonata-bc .sonata-ba-show input[type="text"].locale,
+.sonata-bc .box-primary input[type="text"].locale,
 .sonata-bc .sonata-ba-form select.locale,
-.sonata-bc .sonata-ba-show select.locale {
+.sonata-bc .sonata-ba-show select.locale,
+.sonata-bc .box-primary select.locale {
   padding-left: 35px !important;
   background-position: 5px center;
 }
 .sonata-bc .sonata-ba-form textarea.locale,
-.sonata-bc .sonata-ba-show textarea.locale {
+.sonata-bc .sonata-ba-show textarea.locale,
+.sonata-bc .box-primary textarea.locale {
   padding-left: 35px;
   background-position: 5px 5px;
 }
 .sonata-bc .sonata-ba-form label.wysiwyg.locale,
 .sonata-bc .sonata-ba-show label.wysiwyg.locale,
+.sonata-bc .box-primary label.wysiwyg.locale,
 .sonata-bc .sonata-ba-form label.checkbox.locale,
-.sonata-bc .sonata-ba-show label.checkbox.locale {
+.sonata-bc .sonata-ba-show label.checkbox.locale,
+.sonata-bc .box-primary label.checkbox.locale {
   padding-right: 35px;
   background-position: right bottom;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"],
-.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"] {
+.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"],
+.sonata-bc .box-primary .form-horizontal .controls input[type="checkbox"] {
   /*top: 5px;*/
   position: relative;
   width: 15px;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"].locale,
-.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"].locale {
+.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"].locale,
+.sonata-bc .box-primary .form-horizontal .controls input[type="checkbox"].locale {
   width: 65px;
   background-position: 0 center;
 }
 .sonata-bc .sonata-ba-form .form-horizontal .controls input[type="checkbox"]:before,
-.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"]:before {
+.sonata-bc .sonata-ba-show .form-horizontal .controls input[type="checkbox"]:before,
+.sonata-bc .box-primary .form-horizontal .controls input[type="checkbox"]:before {
   margin-right: 35px;
+}
+.sonata-bc .sonata-ba-show .locale_switcher {
+  margin-right: 15px;
 }
 .sonata-bc.locale_nl label.wysiwyg.locale,
 .sonata-bc.locale_nl label.checkbox.locale,

--- a/Resources/public/less/sonata-translation.less
+++ b/Resources/public/less/sonata-translation.less
@@ -3,7 +3,7 @@
  */
 .sonata-bc {
 
-    .sonata-ba-form, .sonata-ba-show {
+    .sonata-ba-form, .sonata-ba-show, .box-primary {
         .locale_switcher {
             padding: 1px 0 0 0;
             text-align: right;

--- a/Resources/views/Block/block_locale_switcher.html.twig
+++ b/Resources/views/Block/block_locale_switcher.html.twig
@@ -2,8 +2,15 @@
 {% set admin  = block_context.settings.admin %}
 {% set locale_switcher_route = block_context.settings.locale_switcher_route %}
 {% set locale_switcher_route_parameters = block_context.settings.locale_switcher_route_parameters %}
+{% set currentLocale = object.locale %}
 
-{% if (object is translatable) %}
+{% if (admin.class is translatable) %}
+    {% for extension in admin.extensions %}
+        {% if (extension.translatableLocale is defined) %}
+            {% set currentLocale = extension.translatableLocale(admin) %}
+        {% endif %}
+    {% endfor %}
+
     <div class="locale_switcher">
         {% spaceless %}
             {% for locale in sonata_translation_locales %}
@@ -19,7 +26,7 @@
                         {'id': admin.id(object), 'tl': locale}|merge(locale_switcher_route_parameters)
                     ) }}"
                    accesskey=""
-                   class=" {% if (object.locale == locale) %} active {% endif %}"
+                   class=" {% if (currentLocale == locale) %} active {% endif %}"
                    title="{{ 'admin.locale_switcher.tooltip' |trans([], 'SonataTranslationBundle') }}">
                     <img src="{{ asset('bundles/sonatatranslation/img/flags/' ~ locale[-2:2]|lower ~ '.png')}}" />
                 </a>

--- a/Resources/views/Block/block_locale_switcher.html.twig
+++ b/Resources/views/Block/block_locale_switcher.html.twig
@@ -2,11 +2,12 @@
 {% set admin  = block_context.settings.admin %}
 {% set locale_switcher_route = block_context.settings.locale_switcher_route %}
 {% set locale_switcher_route_parameters = block_context.settings.locale_switcher_route_parameters %}
-{% set currentLocale = object.locale %}
 
-{% if (admin.class is translatable) %}
+{% if admin.class is translatable %}
+    {% set currentLocale = object.locale|default(null) %}
+
     {% for extension in admin.extensions %}
-        {% if (extension.translatableLocale is defined) %}
+        {% if extension.translatableLocale is defined %}
             {% set currentLocale = extension.translatableLocale(admin) %}
         {% endif %}
     {% endfor %}
@@ -14,8 +15,8 @@
     <div class="locale_switcher">
         {% spaceless %}
             {% for locale in sonata_translation_locales %}
-                {% if (locale_switcher_route is empty) %}
-                    {% if (object.id) %}
+                {% if locale_switcher_route is empty %}
+                    {% if object.id %}
                         {% set locale_switcher_route = 'edit' %}
                     {% else %}
                         {% set locale_switcher_route = 'create' %}
@@ -26,7 +27,7 @@
                         {'id': admin.id(object), 'tl': locale}|merge(locale_switcher_route_parameters)
                     ) }}"
                    accesskey=""
-                   class=" {% if (currentLocale == locale) %} active {% endif %}"
+                   class=" {% if currentLocale == locale %} active {% endif %}"
                    title="{{ 'admin.locale_switcher.tooltip' |trans([], 'SonataTranslationBundle') }}">
                     <img src="{{ asset('bundles/sonatatranslation/img/flags/' ~ locale[-2:2]|lower ~ '.png')}}" />
                 </a>

--- a/Tests/Traits/GedmoOrmTest.php
+++ b/Tests/Traits/GedmoOrmTest.php
@@ -14,7 +14,7 @@ namespace Sonata\TranslationBundle\Tests\Traits;
 use Doctrine\Common\EventManager;
 use Gedmo\Translatable\TranslatableListener;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
-use Sonata\DoctrineORMAdminBundle\Filter\CallbackFilter;
+use Sonata\TranslationBundle\Filter\TranslationFieldFilter;
 use Sonata\TranslationBundle\Test\DoctrineOrmTestCase;
 use Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslatable;
 use Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslation;
@@ -86,18 +86,13 @@ class GedmoOrmTest extends DoctrineOrmTestCase
                        ->from(self::ARTICLE, 'o');
         $builder = new ProxyQuery($qb);
 
-        $filter = new CallbackFilter();
-        $filter->initialize('title', array(
-            'callback' => array(
-                'Sonata\TranslationBundle\Admin\Extension\Gedmo\TranslatableAdminExtension',
-                'translationFieldFilter',
-            ),
-        ));
+        $filter = new TranslationFieldFilter();
+        $filter->initialize('title');
 
         $filter->filter($builder, 'o', 'title', array('type' => null, 'value' => 'foo'));
         $this->assertEquals(
-            'SELECT o FROM '.self::ARTICLE.' o LEFT JOIN o.translations t'
-            ." WHERE (t.field = 'title' AND t.content LIKE '%foo%') OR o.title LIKE '%foo%'",
+            'SELECT o FROM '.self::ARTICLE.' o LEFT JOIN o.translations tff'
+            ." WHERE (tff.field = 'title' AND tff.content LIKE '%foo%') OR o.title LIKE '%foo%'",
             $builder->getDQL()
         );
         $this->assertTrue($filter->isActive());
@@ -110,20 +105,15 @@ class GedmoOrmTest extends DoctrineOrmTestCase
                        ->from(self::ARTICLE, 'o');
         $builder = new ProxyQuery($qb);
 
-        $filter = new CallbackFilter();
-        $filter->initialize('title', array(
-            'callback' => array(
-                'Sonata\TranslationBundle\Admin\Extension\Gedmo\TranslatableAdminExtension',
-                'translationFieldFilter',
-            ),
-        ));
+        $filter = new TranslationFieldFilter();
+        $filter->initialize('title');
 
         $filter->filter($builder, 'o', 'title', array('type' => null, 'value' => null));
         $this->assertEquals(
             'SELECT o FROM '.self::ARTICLE.' o',
             $builder->getDQL()
         );
-        $this->assertNull($filter->isActive());
+        $this->assertFalse($filter->isActive());
     }
 
     public function testTranslationFieldFilterIfAlreadyJoined()
@@ -131,21 +121,16 @@ class GedmoOrmTest extends DoctrineOrmTestCase
         $qb = $this->em->createQueryBuilder()
                        ->select('o')
                        ->from(self::ARTICLE, 'o')
-                       ->leftJoin('o.translations', 't');
+                       ->leftJoin('o.translations', 'tff');
         $builder = new ProxyQuery($qb);
 
-        $filter = new CallbackFilter();
-        $filter->initialize('title', array(
-            'callback' => array(
-                'Sonata\TranslationBundle\Admin\Extension\Gedmo\TranslatableAdminExtension',
-                'translationFieldFilter',
-            ),
-        ));
+        $filter = new TranslationFieldFilter();
+        $filter->initialize('title');
 
         $filter->filter($builder, 'o', 'title', array('type' => null, 'value' => 'foo'));
         $this->assertEquals(
-            'SELECT o FROM '.self::ARTICLE.' o LEFT JOIN o.translations t'
-            ." WHERE (t.field = 'title' AND t.content LIKE '%foo%') OR o.title LIKE '%foo%'",
+            'SELECT o FROM '.self::ARTICLE.' o LEFT JOIN o.translations tff'
+            ." WHERE (tff.field = 'title' AND tff.content LIKE '%foo%') OR o.title LIKE '%foo%'",
             $builder->getDQL()
         );
         $this->assertTrue($filter->isActive());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is BC.

fix #81, fix #83

continuation of #83, #84, #119

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- [gedmo translations] Added content language switcher to lists
- [gedmo translations] Added available translations filter 
```

## Subject

From original PR:
> In the configureQuery, with the translatable listener the locale is changed for Doctrine and data are translated on the list.

> translationFieldFilter is a callback method to use on doctrine_orm_callback filter to filter on field and on its translation.

I merged conflicts, fixed null exception in block template and added documentation for `translationFieldFilter`.