### PR TITLE
use Sonata\BlockBundle\Block\Service\AbstractBlockService instead of deprecated Sonata\BlockBundle\Block\BaseBlockService

### DIFF
--- a/Block/LocaleSwitcherBlockService.php
+++ b/Block/LocaleSwitcherBlockService.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\TranslationBundle\Block;
 
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -20,7 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */
-class LocaleSwitcherBlockService extends BaseBlockService
+class LocaleSwitcherBlockService extends AbstractBlockService
 {
     /**
      * NEXT_MAJOR: remove this method.

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": "^5.4 || ^7.0",
         "sonata-project/admin-bundle": "^3.1",
+        "sonata-project/block-bundle": "^3.2",
         "sonata-project/core-bundle": "^3.0",
         "symfony/framework-bundle": "^2.3 || ^3.0",
         "symfony/options-resolver": "^2.3 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- use `Sonata\BlockBundle\Block\Service\AbstractBlockService` instead of deprecated `Sonata\BlockBundle\Block\BaseBlockService` in `LocaleSwitcherBlockService`
```
