### PR TITLE
Twig 2.0 compatibility

### DIFF
--- a/Tests/DependencyInjection/SonataTranslationExtensionTest.php
+++ b/Tests/DependencyInjection/SonataTranslationExtensionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TranslationBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\TranslationBundle\DependencyInjection\SonataTranslationExtension;
+
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class SonataTranslationExtensionTest extends AbstractExtensionTestCase
+{
+    public function testLoadServiceDefinitionWhenSonataDoctrineORMAdminBundleBundleIsRegistered()
+    {
+        $this->container->setParameter('kernel.bundles', array('SonataDoctrineORMAdminBundle' => 'whatever'));
+        $this->load();
+        $this->assertContainerBuilderHasService(
+            'sonata_translation.checker.translatable',
+            'Sonata\TranslationBundle\Checker\TranslatableChecker'
+        );
+        $this->assertContainerBuilderHasService(
+            'sonata_translation.filter.type.translation_field',
+            'Sonata\TranslationBundle\Filter\TranslationFieldFilter'
+        );
+    }
+
+    protected function getContainerExtensions()
+    {
+        return array(new SonataTranslationExtension());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sonata-project/core-bundle": "^3.0",
         "symfony/framework-bundle": "^2.3 || ^3.0",
         "symfony/options-resolver": "^2.3 || ^3.0",
-        "twig/twig": "^1.23"
+        "twig/twig": "^1.23 || ^2.0"
     },
     "require-dev": {
         "knplabs/doctrine-behaviors": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "require-dev": {
         "knplabs/doctrine-behaviors": "^1.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^0.5 || ^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "stof/doctrine-extensions-bundle": "^1.1",
         "symfony/phpunit-bridge": "^2.7 || ^3.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- support of Twig 2.0
```
