### PR TITLE
Fix Case

### DIFF
--- a/DependencyInjection/SonataTranslationExtension.php
+++ b/DependencyInjection/SonataTranslationExtension.php
@@ -38,7 +38,7 @@ class SonataTranslationExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $bundles = $container->getParameter('kernel.bundles');
-        if (array_key_exists('SonataDoctrineOrmAdminBundle', $bundles)) {
+        if (array_key_exists('SonataDoctrineORMAdminBundle', $bundles)) {
             $loader->load('service_orm.xml');
         }
 


### PR DESCRIPTION
Hi,

I have a bug when i clear my cache because sf search SonataDoctrineOrmAdminBundle..

And the correcte name of the bundle is : SonataDoctrineORMAdminBundle
