### PR TITLE
added captions to TOC tree in docs

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -14,10 +14,9 @@ This bundle adds a locale switcher block in :
 * **ORM** : integrates Doctrine ORM entities with Gedmo extensions
 * **PHPCR**: integrates Doctrine PHPCR ODM
 
-Reference Guide
----------------
-
 .. toctree::
+   :caption: Reference Guide
+   :name: reference-guide
    :maxdepth: 1
    :numbered:
 


### PR DESCRIPTION
I am targeting this branch, because this is a docs change.

## Subject

Added captions to toc tree

This PR is based on the change of @dmarkowicz in https://github.com/sonata-project/SonataAdminBundle/pull/4387
