### PR TITLE
Translate phpcr lists

### DIFF
--- a/Admin/Extension/Phpcr/TranslatableAdminExtension.php
+++ b/Admin/Extension/Phpcr/TranslatableAdminExtension.php
@@ -12,14 +12,28 @@
 namespace Sonata\TranslationBundle\Admin\Extension\Phpcr;
 
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Translation\LocaleChooser\LocaleChooser;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\TranslationBundle\Admin\Extension\AbstractTranslatableAdminExtension;
+use Sonata\TranslationBundle\Checker\TranslatableChecker;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */
 class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
 {
+    /**
+     * @var LocaleChooser
+     */
+    private $localeChooser;
+
+    public function __construct(TranslatableChecker $translatableChecker, LocaleChooser $localeChooser)
+    {
+        parent::__construct($translatableChecker);
+        $this->localeChooser = $localeChooser;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -41,6 +55,14 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
                 $documentManager->bindTranslation($object, $locale);
             }
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list')
+    {
+        $this->localeChooser->setLocale($this->getTranslatableLocale($admin));
     }
 
     /**

--- a/Resources/config/service_phpcr.xml
+++ b/Resources/config/service_phpcr.xml
@@ -7,6 +7,7 @@
         <service id="sonata_translation.admin.extension.phpcr_translatable" class="%sonata_translation.admin.extension.phpcr_translatable.class%">
             <tag name="sonata.admin.extension"/>
             <argument type="service" id="sonata_translation.checker.translatable"/>
+            <argument type="service" id="doctrine_phpcr.odm.locale_chooser"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
I am targeting this branch, because it's a BC new feature.

## Changelog

```markdown
### Added
- Added phpcr lists translations
```

## Subject

Hi, I just installed this bundle to translate phpcr elements, and I noticed the lists are not correctly translated.

I hope that's the correct way to achieve this !