### PR TITLE
Fix RuntimeException in sonata:admin:explain command

### DIFF
--- a/Admin/Extension/AbstractTranslatableAdminExtension.php
+++ b/Admin/Extension/AbstractTranslatableAdminExtension.php
@@ -68,7 +68,7 @@ abstract class AbstractTranslatableAdminExtension extends AbstractAdminExtension
     public function getTranslatableLocale(AdminInterface $admin)
     {
         if ($this->translatableLocale == null) {
-            if ($admin->getRequest()) {
+            if ($admin->hasRequest()) {
                 $this->translatableLocale = $admin->getRequest()->get(self::TRANSLATABLE_LOCALE_PARAMETER);
             }
             if ($this->translatableLocale == null) {

--- a/Tests/AdminExtension/Knplabs/TranslatableAdminExtensionTest.php
+++ b/Tests/AdminExtension/Knplabs/TranslatableAdminExtensionTest.php
@@ -50,6 +50,7 @@ class TranslatableAdminExtensionTest extends WebTestCase
 
         $this->admin = $this->prophesize('Sonata\AdminBundle\Admin\AdminInterface');
         $this->admin->getRequest()->willReturn($request->reveal());
+        $this->admin->hasRequest()->willReturn(true);
 
         $this->object = new TranslatableEntity();
     }
@@ -61,7 +62,7 @@ class TranslatableAdminExtensionTest extends WebTestCase
         $this->assertEquals('es', $this->object->getLocale());
     }
 
-    public function testAlertObjectForTranslatableObject()
+    public function testAlterObjectForTranslatableObject()
     {
         $this->extension->alterObject($this->admin->reveal(), $this->object);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #164

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix RuntimeException in sonata:admin:explain command
```

## Subject
RuntimeException is thrown in `sonata:admin:explain` command and output is truncated.
<!-- Describe your Pull Request content here -->
