### PR TITLE
Allow to test TranslationFieldFilter and ORM Personal Translation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,14 @@
         "knplabs/doctrine-behaviors": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^0.5 || ^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
+        "sonata-project/doctrine-orm-admin-bundle": "^3.1",
         "stof/doctrine-extensions-bundle": "^1.1",
         "symfony/phpunit-bridge": "^2.7 || ^3.0"
     },
     "suggest": {
         "doctrine/phpcr-odm": "if you translate odm documents",
         "knplabs/doctrine-behaviors": "if you translate orm entities with the knplabs behaviours",
+        "sonata-project/doctrine-orm-admin-bundle": "if you translate orm entities and search on translated fields",
         "stof/doctrine-extensions-bundle": "if you translate orm entities with the gedmo extensions"
     },
     "conflict": {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is BC tests improvement.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->
No need, bacause it is affects only dev packages.

## Subject

<!-- Describe your Pull Request content here -->
Travis skip 4 unit tests because no dependency.
```
............SSSS..                                                18 / 18 (100%)

Time: 3.1 seconds, Memory: 22.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 18, Assertions: 36, Skipped: 4.
```
I added ~~additional target for Travis~~ "sonata-project/doctrine-orm-admin-bundle" to `composer.json` dev packages. It is needed to test `TranslationFieldFilter` (which extends `Sonata\DoctrineORMAdminBundle\Filter\Filter`) and Personal Translation.