### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/Filter/TranslationFieldFilter.php
+++ b/Filter/TranslationFieldFilter.php
@@ -12,7 +12,10 @@
 namespace Sonata\TranslationBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\DoctrineORMAdminBundle\Filter\Filter;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 final class TranslationFieldFilter extends Filter
 {
@@ -73,12 +76,8 @@ final class TranslationFieldFilter extends Filter
     public function getDefaultOptions()
     {
         return [
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                : 'text', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                : 'hidden', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'field_type' => TextType::class,
+            'operator_type' => HiddenType::class,
             'operator_options' => [],
         ];
     }
@@ -88,12 +87,7 @@ final class TranslationFieldFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return [$type, [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/composer.json
+++ b/composer.json
@@ -17,22 +17,22 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^7.0",
+        "php": "^7.1",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/block-bundle": "^3.2",
         "sonata-project/core-bundle": "^3.0",
-        "symfony/framework-bundle": "^2.3 || ^3.0",
-        "symfony/options-resolver": "^2.3 || ^3.0",
+        "symfony/framework-bundle": "^2.8 || ^3.2",
+        "symfony/options-resolver": "^2.8 || ^3.2",
         "twig/twig": "^1.23 || ^2.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4.5",
         "knplabs/doctrine-behaviors": "^1.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^0.5 || ^1.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/doctrine-orm-admin-bundle": "^3.1",
         "stof/doctrine-extensions-bundle": "^1.1",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {
         "doctrine/phpcr-odm": "if you translate odm documents",


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Removed usage of old form type aliases

### Removed
- support for old versions of php and Symfony
```
