### PR TITLE
Bump composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,16 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "sonata-project/admin-bundle": "^3.1",
-        "sonata-project/block-bundle": "^3.2",
-        "sonata-project/core-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.23",
+        "sonata-project/block-bundle": "^3.4",
+        "sonata-project/core-bundle": "^3.6",
         "symfony/framework-bundle": "^2.8 || ^3.2",
         "symfony/options-resolver": "^2.8 || ^3.2",
-        "twig/twig": "^1.23 || ^2.0"
+        "twig/twig": "^1.35 || ^2.4"
     },
     "require-dev": {
-        "doctrine/orm": "^2.4.5",
-        "knplabs/doctrine-behaviors": "^1.0",
+        "doctrine/orm": "^2.5",
+        "knplabs/doctrine-behaviors": "^1.4",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/doctrine-orm-admin-bundle": "^3.1",


### PR DESCRIPTION
Old versions seem to make Composer hang.

This is a test for this PR: https://github.com/sonata-project/SonataTranslationBundle/pull/200