### PR TITLE
Decouple from Templating Component, Stage 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "sonata-project/admin-bundle": "^3.28",
-        "sonata-project/block-bundle": "^3.8",
+        "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.7.1",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -85,7 +85,7 @@ Extend the `SonataAdminBundle layout`_ and add the SonataTranslationBundle style
 .. code-block:: html+jinja
 
     {# app/Resources/views/admin/layout.html.twig #}
-    {% extends 'SonataAdminBundle::standard_layout.html.twig' %}
+    {% extends '@SonataAdmin/standard_layout.html.twig' %}
 
     {% block stylesheets %}
         {{  parent() }}

--- a/src/Block/LocaleSwitcherBlockService.php
+++ b/src/Block/LocaleSwitcherBlockService.php
@@ -41,7 +41,7 @@ class LocaleSwitcherBlockService extends AbstractBlockService
             [
                 'admin' => null,
                 'object' => null,
-                'template' => 'SonataTranslationBundle:Block:block_locale_switcher.html.twig',
+                'template' => '@SonataTranslation/Block/block_locale_switcher.html.twig',
                 'locale_switcher_route' => null,
                 'locale_switcher_route_parameters' => [],
             ]

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -7,7 +7,7 @@
         <service id="sonata_translation.block.locale_switcher" class="%sonata_translation.block.locale_switcher.class%">
             <tag name="sonata.block"/>
             <argument>sonata_translation.block.locale_switcher</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Switch all templates references to Twig namespaced syntax
- Switch from templating service to sonata.templating
```

## To do

- [X] Switch all templates references to Twig namespaced syntax. Update docs, src and tests
- [x] Add `sonata-project/block-bundle` to composer.json
- [x] Switch from `templating` service to `sonata.templating`

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See sonata-project/dev-kit#380 for details