### PR TITLE
Update installation documentation for Symfony Flex

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -9,7 +9,7 @@ following command to download the latest stable version of this bundle:
 
 .. code-block:: bash
 
-    $ composer require sonata-project/translation-bundle "~1"
+    $ composer require sonata-project/translation-bundle
 
 This command requires you to have Composer installed globally, as explained
 in the `installation chapter`_ of the Composer documentation.
@@ -18,7 +18,22 @@ Step 2: Enable the Bundle
 -------------------------
 
 Then, enable the bundle by adding it to the list of registered bundles
-in the ``app/AppKernel.php`` file of your project:
+in ``bundles.php`` file of your project:
+
+.. code-block:: php
+
+    <?php
+
+    // config/bundles.php
+
+    return [
+        //...
+        Sonata\TranslationBundle\SonataTranslationBundle::class => ['all' => true],
+    ];
+
+.. note::
+    If you are not using Symfony Flex, you should enable bundle in your
+    ``AppKernel.php``.
 
 .. code-block:: php
 
@@ -51,7 +66,7 @@ To use the ``TranslationBundle``, add the following lines to your application co
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # config/packages/sonata.yaml
 
         sonata_translation:
             locales: [en, fr, it, nl, es]
@@ -72,6 +87,10 @@ Key                 Description
 ==================  ============================================================================
 
 .. note::
+    If you are not using Symfony Flex, this configuration should be added
+    to ``app/config/config.yml``.
+
+.. note::
 
     If you are using the SonatAdminBundle with the SonataDoctrineORMAdminBundle_, you should
     read the :doc:`ORM chapter </reference/orm>`. If you are using SonataDoctrinePhpcrAdminBundle_,
@@ -84,28 +103,30 @@ Extend the `SonataAdminBundle layout`_ and add the SonataTranslationBundle style
 
 .. code-block:: html+jinja
 
-    {# app/Resources/views/admin/layout.html.twig #}
+    {# templates/admin/layout.html.twig #}
     {% extends '@SonataAdmin/standard_layout.html.twig' %}
 
     {% block stylesheets %}
         {{  parent() }}
 
-        {# If you're using less, you can also use the
-           '@SonataTranslationBundle/Resources/public/less/sonata-translation.less' template #}
-        {% stylesheets
-            '@SonataTranslationBundle/Resources/public/css/sonata-translation.css'
-        %}
-            <link rel="stylesheet" href="{{ asset_url }}" />
-        {% endstylesheets %}
+         <link rel="stylesheet" href="{{ asset('@SonataTranslationBundle/Resources/public/css/sonata-translation.css') }}" />
     {% endblock %}
+
+.. note::
+    If you are not using Symfony Flex, this template should be created
+    in ``app/Resources/views``.
 
 .. code-block:: yaml
 
-    # app/config/config.yml
+    # config/packages/sonata.yaml
     sonata_admin:
         templates:
             layout: admin/layout.html.twig
         # ...
+
+.. note::
+    If you are not using Symfony Flex, this configuration should be added
+    to ``app/config/config.yml``.
 
 Now, you're good to go!
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am updating documentation for Symfony Flex.

## Subject

Updating documentation to adopt new flex structure.
