### PR TITLE
Add style for locale switcher in modal

### DIFF
--- a/src/Resources/public/css/sonata-translation.css
+++ b/src/Resources/public/css/sonata-translation.css
@@ -3,6 +3,7 @@
  */
 .sonata-bc .sonata-ba-form .locale_switcher,
 .sonata-bc .sonata-ba-show .locale_switcher,
+.sonata-bc .modal .locale_switcher,
 .sonata-bc .box-primary .locale_switcher {
   padding: 1px 0 0 0;
   text-align: right;
@@ -12,6 +13,7 @@
 }
 .sonata-bc .sonata-ba-form .locale_switcher a,
 .sonata-bc .sonata-ba-show .locale_switcher a,
+.sonata-bc .modal .locale_switcher a,
 .sonata-bc .box-primary .locale_switcher a {
   margin-right: 0;
   padding: 2px;
@@ -19,11 +21,13 @@
 }
 .sonata-bc .sonata-ba-form .locale_switcher a.active,
 .sonata-bc .sonata-ba-show .locale_switcher a.active,
+.sonata-bc .modal .locale_switcher a.active,
 .sonata-bc .box-primary .locale_switcher a.active {
   opacity: 1;
 }
 .sonata-bc .sonata-ba-form .locale_switcher a:hover,
 .sonata-bc .sonata-ba-show .locale_switcher a:hover,
+.sonata-bc .modal .locale_switcher a:hover,
 .sonata-bc .box-primary .locale_switcher a:hover {
   opacity: 1;
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- language switcher does not have the same style in modal
```
Before:

![screenshot from 2018-02-21 21-06-39](https://user-images.githubusercontent.com/13528674/36502746-2c79fe0a-174b-11e8-8774-1980191fcc8b.png)

After:

![screenshot from 2018-02-21 21-05-56](https://user-images.githubusercontent.com/13528674/36502761-32b23a8a-174b-11e8-9715-351f0a37e433.png)

## Subject

Language switcher did not have the same style inside of modal as rest of app, this fixes it.