### PR TITLE
Check if 'sonata_translation.checker.translatable' service exists

### DIFF
--- a/src/DependencyInjection/SonataTranslationExtension.php
+++ b/src/DependencyInjection/SonataTranslationExtension.php
@@ -94,6 +94,9 @@ class SonataTranslationExtension extends Extension
      */
     protected function configureChecker(ContainerBuilder $container, $translationTargets)
     {
+        if (!$container->hasDefinition('sonata_translation.checker.translatable')) {
+            return;
+        }
         $translatableCheckerDefinition = $container->getDefinition('sonata_translation.checker.translatable');
 
         $supportedInterfaces = [];

--- a/tests/DependencyInjection/SonataTranslationExtensionTest.php
+++ b/tests/DependencyInjection/SonataTranslationExtensionTest.php
@@ -33,6 +33,14 @@ final class SonataTranslationExtensionTest extends AbstractExtensionTestCase
         );
     }
 
+    public function testLoadServiceDefinitionNoCheckerTranslatable()
+    {
+        $this->container->setParameter('kernel.bundles', []);
+        $this->load();
+
+        $this->assertContainerBuilderNotHasService('sonata_translation.checker.translatable');
+    }
+
     protected function getContainerExtensions()
     {
         return [new SonataTranslationExtension()];

--- a/tests/Model/GedmoTest.php
+++ b/tests/Model/GedmoTest.php
@@ -53,6 +53,6 @@ class GedmoTest extends TestCase
         $this->assertSame('Title it', $model->getTranslation('title', 'it'));
         $this->assertSame('Title es', $model->getTranslation('title', 'es'));
 
-        $this->assertSame(3, count($model->getTranslations()));
+        $this->assertCount(3, $model->getTranslations());
     }
 }

--- a/tests/Traits/GedmoTest.php
+++ b/tests/Traits/GedmoTest.php
@@ -54,6 +54,6 @@ class GedmoTest extends TestCase
         $this->assertSame('Title it', $model->getTranslation('title', 'it'));
         $this->assertSame('Title es', $model->getTranslation('title', 'es'));
 
-        $this->assertSame(3, count($model->getTranslations()));
+        $this->assertCount(3, $model->getTranslations());
     }
 }


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Fixed
- Added check if translatable checker service exists
```

## Subject

`SonataDoctrineORMBundle` is optional dependency for this bundle. And if `SonataDoctrineORMBundle` was not installed, after installation there would be a error during `cache:clear` command:

> You have requested a non-existent service "sonata_translation.checker.translatable"

With this PR this error will not appear with the following default configuration (recipe =)

```yaml
sonata_admin:
    assets:
        extra_stylesheets:
            - bundles/sonatatranslation/css/sonata-translation.css

sonata_block:
    blocks:
        sonata_translation.block.locale_switcher: ~

sonata_translation:
    locales: [en]
    default_locale: en
    #gedmo:
    #    enabled: true
    #knplabs:
    #    enabled: true
```
