### PR TITLE
Added string typecheck to prevent exception

### DIFF
--- a/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
@@ -33,7 +33,7 @@ class AdminExtensionCompilerPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $attributes) {
             $admin = $container->getDefinition($id);
             $modelClass = $container->getParameterBag()->resolveValue($admin->getArgument(1));
-            if (!class_exists($modelClass)) {
+            if (!is_string($modelClass) || !class_exists($modelClass)) {
                 continue;
             }
             $modelClassReflection = new \ReflectionClass($modelClass);

--- a/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
@@ -33,7 +33,7 @@ class AdminExtensionCompilerPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $attributes) {
             $admin = $container->getDefinition($id);
             $modelClass = $container->getParameterBag()->resolveValue($admin->getArgument(1));
-            if (!is_string($modelClass) || !class_exists($modelClass)) {
+            if (!\is_string($modelClass) || !class_exists($modelClass)) {
                 continue;
             }
             $modelClassReflection = new \ReflectionClass($modelClass);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Added String typecheck to the AdminExtensionCompilerPass file before calling class_exists()

When defining an Admin service the Entity argument can be left empty. This causes an Exception in the `AdminExtensionCompilerPass` when calling class_exists(), because strict_types is set to 1.  


I am targeting this branch, because this bugfix is backwards compatible. 



## Changelog
```markdown
### Fixed
Added is_string check in AdminExtensionCompilerPass
```
