### PR TITLE
Make it possible to create an admin without entity

### DIFF
--- a/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
@@ -33,7 +33,7 @@ class AdminExtensionCompilerPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $attributes) {
             $admin = $container->getDefinition($id);
             $modelClass = $container->getParameterBag()->resolveValue($admin->getArgument(1));
-            if (!class_exists($modelClass)) {
+            if (!$modelClass || !class_exists($modelClass)) {
                 continue;
             }
             $modelClassReflection = new \ReflectionClass($modelClass);


### PR DESCRIPTION
Currently when creating an admin with no entity (`~` as argument), the [get_class](https://github.com/storefront-bvba/SonataTranslationBundle/blob/af09eb0f51162ae05c5365835869f4ddfeed9a98/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php#L36) throws `class_exists() expects parameter 1 to be string`. To overcome this I would first check if there's a model class and after that check if it exists. 
An other solution is to provide an empty string as argument but that's a bit hacky.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a small improvement which AFAIK wont break a thing.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Admin without entity shouldn't be restricted
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
