### PR TITLE
Check if method getLocale exists before to use it

### DIFF
--- a/src/EventSubscriber/UserLocaleSubscriber.php
+++ b/src/EventSubscriber/UserLocaleSubscriber.php
@@ -40,7 +40,7 @@ final class UserLocaleSubscriber implements EventSubscriberInterface
     {
         $user = $event->getAuthenticationToken()->getUser();
 
-        if (null !== $user->getLocale()) {
+        if (\is_callable([$user, 'getLocale']) && null !== $user->getLocale()) {
             $this->session->set('_locale', $user->getLocale());
         }
     }

--- a/tests/EventSubscriber/LocalizedUser.php
+++ b/tests/EventSubscriber/LocalizedUser.php
@@ -18,29 +18,22 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /**
  * @author Jonathan Vautrin <jvautrin@pro-info.be>
  */
-class User implements UserInterface
+class LocalizedUser extends User implements UserInterface
 {
-    public function getRoles()
+    private $locale;
+
+    public function __construct(string $locale)
     {
-        return [];
+        $this->locale = $locale;
     }
 
-    public function getPassword()
+    public function getLocale()
     {
-        return null;
+        return $this->locale;
     }
 
-    public function getSalt()
+    public function setLocale($locale)
     {
-        return null;
-    }
-
-    public function getUsername()
-    {
-        return null;
-    }
-
-    public function eraseCredentials()
-    {
+        $this->locale = $locale;
     }
 }


### PR DESCRIPTION
## Subject
I am targeting this branch, because this is a bug fix.

Closes #297 

## Changelog
```markdown
### Fixed
Check if method getLocale exists before to use it in UserLocaleListener
```
