### PR TITLE
Fixed issue caused by always using the default entity manager

### DIFF
--- a/src/Admin/Extension/Gedmo/TranslatableAdminExtension.php
+++ b/src/Admin/Extension/Gedmo/TranslatableAdminExtension.php
@@ -45,7 +45,7 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
             $translatableListener->setTranslatableLocale($this->getTranslatableLocale($admin));
             $translatableListener->setTranslationFallback(false);
 
-            $this->getContainer($admin)->get('doctrine')->getManager()->refresh($object);
+            $this->getContainer($admin)->get('doctrine')->getManagerForClass(get_class($object))->refresh($object);
             $object->setLocale($this->getTranslatableLocale($admin));
         }
     }


### PR DESCRIPTION
## Fixed issue caused by always using the default entity manager

When using multiple entity managers with different entities in their chains, this extension always fetched the default entity manager from the registry instead of the one for the given object

I am targeting this branch, because it is a BC bug fix.

## Changelog

```markdown
### Fixed
Fixed issue caused by always using the default entity manager
```
