### PR TITLE
Dropping support for symfony < 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
         "sonata-project/admin-bundle": "^3.43",
         "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.12.0",
-        "symfony/config": "^2.8 || ^3.2 || ^4.0",
-        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
-        "symfony/form": "^2.8 || ^3.2 || ^4.0",
-        "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
-        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
-        "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0",
+        "symfony/config": "^3.4 || ^4.2",
+        "symfony/dependency-injection": "^3.4 || ^4.2",
+        "symfony/form": "^3.4 || ^4.2",
+        "symfony/http-foundation": "^3.4 || ^4.2",
+        "symfony/http-kernel": "^3.4 || ^4.2",
+        "symfony/options-resolver": "^3.4 || ^4.2",
         "twig/twig": "^1.35 || ^2.4"
     },
     "conflict": {
@@ -43,7 +43,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",
         "sonata-project/doctrine-orm-admin-bundle": "^3.2",
         "stof/doctrine-extensions-bundle": "^1.1",
-        "symfony/framework-bundle": "^2.8.18 || ^3.2.5 || ^4.0",
+        "symfony/framework-bundle": "^3.4 || ^4.2",
         "symfony/phpunit-bridge": "^4.2"
     },
     "suggest": {

--- a/src/Checker/TranslatableChecker.php
+++ b/src/Checker/TranslatableChecker.php
@@ -13,6 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\TranslationBundle\Checker;
 
+use Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatable;
+use Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatableTrait;
+use Sonata\TranslationBundle\Traits\Translatable;
+use Sonata\TranslationBundle\Traits\TranslatableTrait;
+
 /**
  * @author Nicolas Bastien <nbastien@prestaconcept.net>
  */
@@ -70,19 +75,17 @@ class TranslatableChecker
             return false;
         }
 
-        if (\function_exists('class_uses')) {
-            // NEXT_MAJOR: remove Translateable and PersonalTrait.
-            $translateTraits = [
-                'Sonata\TranslationBundle\Traits\Translatable',
-                'Sonata\TranslationBundle\Traits\TranslatableTrait',
-                'Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatable',
-                'Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatableTrait',
-            ];
+        // NEXT_MAJOR: remove Translateable and PersonalTrait.
+        $translateTraits = [
+            Translatable::class,
+            TranslatableTrait::class,
+            PersonalTranslatable::class,
+            PersonalTranslatableTrait::class,
+        ];
 
-            $traits = class_uses($object);
-            if (\count(array_intersect($translateTraits, $traits)) > 0) {
-                return true;
-            }
+        $traits = class_uses($object);
+        if (\count(array_intersect($translateTraits, $traits)) > 0) {
+            return true;
         }
 
         $objectInterfaces = class_implements($object);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This is the same thing as https://github.com/sonata-project/SonataAdminBundle/pull/5733, dropping support of Symfony < 3.4 and >= 4, < 4.2
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for Symfony < 3.4
- Support for Symfony >= 4, < 4.2
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
