### PR TITLE
Big bad bass man 327 language name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/http-foundation": "^3.4 || ^4.2",
         "symfony/http-kernel": "^3.4 || ^4.2",
         "symfony/options-resolver": "^3.4 || ^4.2",
-        "twig/twig": "^1.35 || ^2.4"
+        "twig/twig": "^2.12"
     },
     "conflict": {
         "doctrine/phpcr-odm": ">=3.0",

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -32,7 +32,7 @@ file that was distributed with this source code.
                                     {% for locale in sonata_translation_locales %}
                                     <li role="presentation" class="{{ app.request.locale == locale ? 'active' : '' }}">
                                         <a role="menuitem" tabindex="-1" href="{{ path('sonata.translation.locale', {'locale': locale}) }}">
-                                            {{ locale|language(locale)|capitalize }}
+                                            {{ locale|language_name(locale)|capitalize }}
                                         </a>
                                     </li>
                                     {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixes #327 for Twig >= 2.12

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change requires Twig 2.12. Dropping support for Twig 1.x could be backwards-incompatible.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #327 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- require Twig version 2.12
- change filter in global language switcher to use Twig 2.12 language_name

### Removed
- support for Twig 1.x
```

    ## To do
    
    - [x] Update the tests
    - [x] Update the documentation
    - [x] Add an upgrade note
