### PR TITLE
Drop support of Symfony < 4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,18 @@
     ],
     "require": {
         "php": "^7.1",
-        "sonata-project/admin-bundle": "^3.43",
-        "sonata-project/block-bundle": "^3.11",
-        "symfony/config": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
-        "symfony/form": "^3.4 || ^4.2",
-        "symfony/http-foundation": "^3.4 || ^4.2",
-        "symfony/http-kernel": "^3.4 || ^4.2",
-        "symfony/options-resolver": "^3.4 || ^4.2",
+        "sonata-project/admin-bundle": "^3.58",
+        "sonata-project/block-bundle": "^3.17",
+        "symfony/config": "^4.3",
+        "symfony/dependency-injection": "^4.3",
+        "symfony/form": "^4.3",
+        "symfony/http-foundation": "^4.3",
+        "symfony/http-kernel": "^4.3",
+        "symfony/options-resolver": "^4.3",
         "twig/twig": "^2.12"
     },
     "conflict": {
+        "doctrine/annotations": "<1.8",
         "doctrine/phpcr-odm": ">=3.0",
         "knplabs/doctrine-behaviors": "<1.0 || >=2.0",
         "stof/doctrine-extensions-bundle": "<1.1 || >=2.0"
@@ -42,7 +43,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "sonata-project/doctrine-orm-admin-bundle": "^3.2",
         "stof/doctrine-extensions-bundle": "^1.1",
-        "symfony/framework-bundle": "^3.4.31 || ^4.3.4",
+        "symfony/framework-bundle": "^4.3.4",
         "symfony/phpunit-bridge": "^5.0"
     },
     "suggest": {

--- a/src/Block/LocaleSwitcherBlockService.php
+++ b/src/Block/LocaleSwitcherBlockService.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Twig\Environment;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
@@ -30,12 +31,17 @@ class LocaleSwitcherBlockService extends AbstractBlockService
      */
     private $showCountryFlags;
 
+    /**
+     * NEXT_MAJOR: Remove `$templating` argument.
+     *
+     * @param Environment|string $templatingOrDeprecatedName
+     */
     public function __construct(
-        ?string $name = null,
+        $templatingOrDeprecatedName = null,
         EngineInterface $templating = null,
         ?bool $showCountryFlags = false
     ) {
-        parent::__construct($name, $templating);
+        parent::__construct($templatingOrDeprecatedName, $templating);
         $this->showCountryFlags = $showCountryFlags;
     }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,12 +29,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('sonata_translation');
 
-        // Keep compatibility with symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->root('sonata_translation');
-        } else {
-            $rootNode = $treeBuilder->getRootNode();
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Model/Gedmo/AbstractPersonalTranslatable.php
+++ b/src/Model/Gedmo/AbstractPersonalTranslatable.php
@@ -57,6 +57,8 @@ abstract class AbstractPersonalTranslatable extends AbstractTranslatable
                 return $translation->getContent();
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -6,8 +6,9 @@
     <services>
         <service id="sonata_translation.block.locale_switcher" class="%sonata_translation.block.locale_switcher.class%">
             <tag name="sonata.block"/>
-            <argument>sonata_translation.block.locale_switcher</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
+            <!-- NEXT_MAJOR: Remove "null" argument -->
+            <argument>null</argument>
             <argument>%sonata_translation.locale_switcher_show_country_flags%</argument>
         </service>
     </services>

--- a/src/Traits/Gedmo/PersonalTranslatableTrait.php
+++ b/src/Traits/Gedmo/PersonalTranslatableTrait.php
@@ -45,6 +45,8 @@ trait PersonalTranslatableTrait
                 return $translation->getContent();
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Twig/Extension/SonataTranslationExtension.php
+++ b/src/Twig/Extension/SonataTranslationExtension.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\TranslationBundle\Twig\Extension;
 
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
-use Symfony\Component\Intl\Intl;
+use Symfony\Component\Intl\Locales;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigTest;
@@ -75,6 +75,6 @@ class SonataTranslationExtension extends AbstractExtension
 
     public function getLocaleName(string $locale, ?string $displayLocale = null): ?string
     {
-        return Intl::getLocaleBundle()->getLocaleName($locale, $displayLocale);
+        return Locales::getName($locale, $displayLocale);
     }
 }

--- a/tests/Action/SwitchLocaleActionTest.php
+++ b/tests/Action/SwitchLocaleActionTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 /**
  * @author Jonathan Vautrin <jvautrin@pro-info.be>
  */
-class SwitchLocaleActionTest extends TestCase
+final class SwitchLocaleActionTest extends TestCase
 {
     public function testSwitchLocaleAction(): void
     {

--- a/tests/AdminExtension/Knplabs/TranslatableAdminExtensionTest.php
+++ b/tests/AdminExtension/Knplabs/TranslatableAdminExtensionTest.php
@@ -16,13 +16,15 @@ namespace Sonata\TranslationBundle\Tests\AdminExtension\Knplabs;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\TranslationBundle\Admin\Extension\Knplabs\TranslatableAdminExtension;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
+use Sonata\TranslationBundle\Model\TranslatableInterface;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\Knplabs\TranslatableEntity;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @group  translatable-knplabs
  */
-class TranslatableAdminExtensionTest extends WebTestCase
+final class TranslatableAdminExtensionTest extends WebTestCase
 {
     /**
      * @var AdminInterface
@@ -43,14 +45,14 @@ class TranslatableAdminExtensionTest extends WebTestCase
     {
         $translatableChecker = new TranslatableChecker();
         $translatableChecker->setSupportedInterfaces([
-            'Sonata\TranslationBundle\Model\TranslatableInterface',
+            TranslatableInterface::class,
         ]);
         $this->extension = new TranslatableAdminExtension($translatableChecker);
 
-        $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
+        $request = $this->prophesize(Request::class);
         $request->get('tl')->willReturn('es');
 
-        $this->admin = $this->prophesize('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->prophesize(AdminInterface::class);
         $this->admin->getRequest()->willReturn($request->reveal());
         $this->admin->hasRequest()->willReturn(true);
 
@@ -73,7 +75,7 @@ class TranslatableAdminExtensionTest extends WebTestCase
 
     public function testPreUpdate(): void
     {
-        $object = $this->prophesize('Sonata\TranslationBundle\Tests\Fixtures\Model\Knplabs\TranslatableEntity');
+        $object = $this->prophesize(TranslatableEntity::class);
         $object->mergeNewTranslations()->shouldBeCalled();
 
         $this->extension->preUpdate($this->admin->reveal(), $object->reveal());
@@ -81,7 +83,7 @@ class TranslatableAdminExtensionTest extends WebTestCase
 
     public function testPrePersist(): void
     {
-        $object = $this->prophesize('Sonata\TranslationBundle\Tests\Fixtures\Model\Knplabs\TranslatableEntity');
+        $object = $this->prophesize(TranslatableEntity::class);
         $object->mergeNewTranslations()->shouldBeCalled();
 
         $this->extension->prePersist($this->admin->reveal(), $object->reveal());

--- a/tests/Checker/TranslatableCheckerForKnpTest.php
+++ b/tests/Checker/TranslatableCheckerForKnpTest.php
@@ -15,16 +15,14 @@ namespace Sonata\AdminBundle\Tests\Checker;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
+use Sonata\TranslationBundle\Model\TranslatableInterface;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\Knplabs\TranslatableEntity;
 
 /**
  * @author Alfonso Machado <email@alfonsomachado.com>
  */
-class TranslatableCheckerForKnpTest extends TestCase
+final class TranslatableCheckerForKnpTest extends TestCase
 {
-    /**
-     * @test TranslatableChecker::isTranslatable
-     */
     public function testIsTranslatableOnInterface(): void
     {
         $translatableChecker = new TranslatableChecker();
@@ -34,7 +32,7 @@ class TranslatableCheckerForKnpTest extends TestCase
         $this->assertFalse($translatableChecker->isTranslatable($object));
 
         $translatableChecker->setSupportedInterfaces([
-            'Sonata\TranslationBundle\Model\TranslatableInterface',
+            TranslatableInterface::class,
         ]);
 
         $this->assertTrue($translatableChecker->isTranslatable($object));

--- a/tests/Checker/TranslatableCheckerTest.php
+++ b/tests/Checker/TranslatableCheckerTest.php
@@ -15,6 +15,7 @@ namespace Sonata\TranslationBundle\Tests\Checker;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
+use Sonata\TranslationBundle\Model\TranslatableInterface;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelCustomTranslatable;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelTranslatable;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelUsingTraitTranslatable;
@@ -22,11 +23,8 @@ use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelUsingTraitTranslatable;
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */
-class TranslatableCheckerTest extends TestCase
+final class TranslatableCheckerTest extends TestCase
 {
-    /**
-     * @test TranslatableChecker::isTranslatable
-     */
     public function testIsTranslatableOnInterface(): void
     {
         $translatableChecker = new TranslatableChecker();
@@ -36,15 +34,12 @@ class TranslatableCheckerTest extends TestCase
         $this->assertFalse($translatableChecker->isTranslatable($object));
 
         $translatableChecker->setSupportedInterfaces([
-            'Sonata\TranslationBundle\Model\TranslatableInterface',
+            TranslatableInterface::class,
         ]);
 
         $this->assertTrue($translatableChecker->isTranslatable($object));
     }
 
-    /**
-     * @test TranslatableChecker::isTranslatable
-     */
     public function testIsTranslatableOnModel(): void
     {
         $translatableChecker = new TranslatableChecker();
@@ -54,15 +49,12 @@ class TranslatableCheckerTest extends TestCase
         $this->assertFalse($translatableChecker->isTranslatable($object));
 
         $translatableChecker->setSupportedModels([
-            'Sonata\TranslationBundle\Tests\Fixtures\Model\ModelCustomTranslatable',
+            ModelCustomTranslatable::class,
         ]);
 
         $this->assertTrue($translatableChecker->isTranslatable($object));
     }
 
-    /**
-     * @test TranslatableChecker::isTranslatable
-     */
     public function testIsTranslatableOnTrait(): void
     {
         $translatableChecker = new TranslatableChecker();

--- a/tests/DependencyInjection/SonataTranslationExtensionTest.php
+++ b/tests/DependencyInjection/SonataTranslationExtensionTest.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace Sonata\TranslationBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\DependencyInjection\SonataTranslationExtension;
+use Sonata\TranslationBundle\Filter\TranslationFieldFilter;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
@@ -32,11 +34,11 @@ final class SonataTranslationExtensionTest extends AbstractExtensionTestCase
         $this->load();
         $this->assertContainerBuilderHasService(
             'sonata_translation.checker.translatable',
-            'Sonata\TranslationBundle\Checker\TranslatableChecker'
+            TranslatableChecker::class
         );
         $this->assertContainerBuilderHasService(
             'sonata_translation.filter.type.translation_field',
-            'Sonata\TranslationBundle\Filter\TranslationFieldFilter'
+            TranslationFieldFilter::class
         );
     }
 

--- a/tests/EventSubscriber/LocaleSubscriberTest.php
+++ b/tests/EventSubscriber/LocaleSubscriberTest.php
@@ -18,13 +18,13 @@ use Sonata\TranslationBundle\EventSubscriber\LocaleSubscriber;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * @author Jonathan Vautrin <jvautrin@pro-info.be>
  */
-class LocaleSubscriberTest extends TestCase
+final class LocaleSubscriberTest extends TestCase
 {
     /**
      * Check if LocaleSubscriber set the request locale to the session
@@ -80,9 +80,9 @@ class LocaleSubscriberTest extends TestCase
         $this->assertSame('fr', $request->getLocale());
     }
 
-    private function getEvent(Request $request)
+    private function getEvent(Request $request): RequestEvent
     {
-        return new GetResponseEvent(
+        return new RequestEvent(
             $this->createMock(HttpKernelInterface::class),
             $request,
             HttpKernelInterface::MASTER_REQUEST

--- a/tests/EventSubscriber/LocalizedUser.php
+++ b/tests/EventSubscriber/LocalizedUser.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\TranslationBundle\Tests\EventSubscriber;
 
-use Symfony\Component\Security\Core\User\UserInterface;
-
 /**
  * @author Jonathan Vautrin <jvautrin@pro-info.be>
  */
-class LocalizedUser extends User implements UserInterface
+final class LocalizedUser extends User
 {
     private $locale;
 

--- a/tests/EventSubscriber/UserLocaleSubscriberTest.php
+++ b/tests/EventSubscriber/UserLocaleSubscriberTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 /**
  * @author Jonathan Vautrin <jvautrin@pro-info.be>
  */
-class UserLocaleSubscriberTest extends TestCase
+final class UserLocaleSubscriberTest extends TestCase
 {
     /**
      * Check if session locale is set to user locale at login.

--- a/tests/Fixtures/Traits/ORM/Knplabs/Article.php
+++ b/tests/Fixtures/Traits/ORM/Knplabs/Article.php
@@ -42,7 +42,7 @@ final class Article extends TranslatableEntity
         $this->translations = new ArrayCollection();
     }
 
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }

--- a/tests/Fixtures/Traits/ORM/Knplabs/ArticleTranslation.php
+++ b/tests/Fixtures/Traits/ORM/Knplabs/ArticleTranslation.php
@@ -42,7 +42,7 @@ final class ArticleTranslation
         return $this->title;
     }
 
-    public function setTitle($title)
+    public function setTitle($title): void
     {
         $this->title = $title;
     }

--- a/tests/Model/GedmoTest.php
+++ b/tests/Model/GedmoTest.php
@@ -22,30 +22,24 @@ use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelTranslatable;
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */
-class GedmoTest extends TestCase
+final class GedmoTest extends TestCase
 {
-    /**
-     * @test AbstractTranslatable
-     */
     public function testTranslatableModel(): void
     {
         $model = new ModelTranslatable();
         $model->setLocale('fr');
 
         $this->assertSame('fr', $model->getLocale());
-        $this->assertTrue($model instanceof TranslatableInterface);
+        $this->assertInstanceOf(TranslatableInterface::class, $model);
     }
 
-    /**
-     * @test AbstractPersonalTranslatable and AbstractPersonalTranslation
-     */
     public function testPersonalTranslatableModel(): void
     {
         $model = new ModelPersonalTranslatable();
         $model->setLocale('fr');
 
         $this->assertSame('fr', $model->getLocale());
-        $this->assertTrue($model instanceof TranslatableInterface);
+        $this->assertInstanceOf(TranslatableInterface::class, $model);
 
         $model->addTranslation(new ModelPersonalTranslation('en', 'title', 'Title en'));
         $model->addTranslation(new ModelPersonalTranslation('it', 'title', 'Title it'));

--- a/tests/Model/KnplabsTest.php
+++ b/tests/Model/KnplabsTest.php
@@ -22,12 +22,12 @@ use Sonata\TranslationBundle\Tests\Fixtures\Model\Knplabs\TranslatableEntity;
  */
 final class KnplabsTest extends TestCase
 {
-    public function testTranslatableModel()
+    public function testTranslatableModel(): void
     {
         $model = new TranslatableEntity();
         $model->setLocale('fr');
 
         $this->assertSame('fr', $model->getLocale());
-        $this->assertTrue($model instanceof TranslatableInterface);
+        $this->assertInstanceOf(TranslatableInterface::class, $model);
     }
 }

--- a/tests/Resources/XliffTest.php
+++ b/tests/Resources/XliffTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Translation\Loader\XliffFileLoader;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class XliffTest extends TestCase
+final class XliffTest extends TestCase
 {
     /**
      * @var XliffFileLoader
@@ -32,7 +32,7 @@ class XliffTest extends TestCase
      */
     protected $errors = [];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->loader = new XliffFileLoader();
     }
@@ -40,7 +40,7 @@ class XliffTest extends TestCase
     /**
      * @dataProvider getXliffPaths
      */
-    public function testXliff($path)
+    public function testXliff(string $path): void
     {
         $this->validatePath($path);
 
@@ -52,15 +52,15 @@ class XliffTest extends TestCase
     /**
      * @return array List all path to validate xliff
      */
-    public function getXliffPaths()
+    public function getXliffPaths(): array
     {
-        return [[__DIR__.'/../../Resources/translations']];
+        return [[__DIR__.'/../../src/Resources/translations']];
     }
 
     /**
      * @param string $file The path to the xliff file
      */
-    protected function validateXliff($file)
+    protected function validateXliff(string $file): void
     {
         try {
             $this->loader->load($file, 'en');
@@ -73,7 +73,7 @@ class XliffTest extends TestCase
     /**
      * @param string $path The path to lookup for Xliff file
      */
-    protected function validatePath($path)
+    protected function validatePath(string $path): void
     {
         $files = glob(sprintf('%s/*.xliff', $path));
 

--- a/tests/Traits/GedmoOrmTest.php
+++ b/tests/Traits/GedmoOrmTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\TranslationBundle\Tests\Traits;
 
 use Doctrine\Common\EventManager;
+use Doctrine\ORM\Version;
 use Gedmo\Translatable\TranslatableListener;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\TranslationBundle\Enum\TranslationFilterMode;
@@ -22,10 +23,10 @@ use Sonata\TranslationBundle\Test\DoctrineOrmTestCase;
 use Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslatable;
 use Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslation;
 
-class GedmoOrmTest extends DoctrineOrmTestCase
+final class GedmoOrmTest extends DoctrineOrmTestCase
 {
-    public const ARTICLE = 'Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslatable';
-    public const TRANSLATION = 'Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\ArticlePersonalTranslation';
+    public const ARTICLE = ArticlePersonalTranslatable::class;
+    public const TRANSLATION = ArticlePersonalTranslation::class;
 
     /** @var TranslatableListener */
     private $translatableListener;
@@ -34,7 +35,7 @@ class GedmoOrmTest extends DoctrineOrmTestCase
     {
         parent::setUp();
 
-        if (!class_exists('Doctrine\\ORM\\Version')) {
+        if (!class_exists(Version::class)) {
             $this->markTestSkipped('Doctrine ORM is not available.');
         }
 
@@ -139,7 +140,7 @@ class GedmoOrmTest extends DoctrineOrmTestCase
         $this->assertTrue($filter->isActive());
     }
 
-    protected function getUsedEntityFixtures()
+    protected function getUsedEntityFixtures(): array
     {
         return [
             self::ARTICLE,

--- a/tests/Traits/GedmoTest.php
+++ b/tests/Traits/GedmoTest.php
@@ -14,39 +14,32 @@ declare(strict_types=1);
 namespace Sonata\TranslationBundle\Tests\Traits;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\TranslationBundle\Model\TranslatableInterface;
 use Sonata\TranslationBundle\Tests\Fixtures\Traits\ModelPersonalTranslatable;
 use Sonata\TranslationBundle\Tests\Fixtures\Traits\ModelPersonalTranslation;
 use Sonata\TranslationBundle\Tests\Fixtures\Traits\ModelTranslatable;
-use Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatableTrait;
-use Sonata\TranslationBundle\Traits\TranslatableTrait;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */
 class GedmoTest extends TestCase
 {
-    /**
-     * @test TranslatableTrait
-     */
     public function testTranslatableModel(): void
     {
         $model = new ModelTranslatable();
         $model->setLocale('fr');
 
         $this->assertSame('fr', $model->getLocale());
-        $this->assertTrue($model instanceof \Sonata\TranslationBundle\Model\TranslatableInterface);
+        $this->assertInstanceOf(TranslatableInterface::class, $model);
     }
 
-    /**
-     * @test PersonalTranslatableTrait
-     */
     public function testPersonalTranslatableModel(): void
     {
         $model = new ModelPersonalTranslatable();
         $model->setLocale('fr');
 
         $this->assertSame('fr', $model->getLocale());
-        $this->assertTrue($model instanceof \Sonata\TranslationBundle\Model\TranslatableInterface);
+        $this->assertInstanceOf(TranslatableInterface::class, $model);
 
         $model->addTranslation(new ModelPersonalTranslation('en', 'title', 'Title en'));
         $model->addTranslation(new ModelPersonalTranslation('it', 'title', 'Title it'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Before solving https://github.com/sonata-project/SonataTranslationBundle/issues/335, dropping Symfony < 4.3 and some tests clean up 

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support of Symfony < 4.3
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
