### PR TITLE
Add sonata_language_name twig filter

### DIFF
--- a/src/DependencyInjection/SonataTranslationExtension.php
+++ b/src/DependencyInjection/SonataTranslationExtension.php
@@ -40,6 +40,7 @@ class SonataTranslationExtension extends Extension
 
         $isEnabled = false;
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('twig_intl.xml');
 
         if ($config['locale_switcher']) {
             $loader->load('service_locale_switcher.xml');

--- a/src/Resources/config/twig_intl.xml
+++ b/src/Resources/config/twig_intl.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata_translation.twig.intl_extension" class="Sonata\TranslationBundle\Twig\Extension\IntlExtension">
+            <tag name="twig.extension"/>
+        </service>
+    </services>
+</container>

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -32,7 +32,7 @@ file that was distributed with this source code.
                                     {% for locale in sonata_translation_locales %}
                                     <li role="presentation" class="{{ app.request.locale == locale ? 'active' : '' }}">
                                         <a role="menuitem" tabindex="-1" href="{{ path('sonata.translation.locale', {'locale': locale}) }}">
-                                            {{ locale|language_name(locale)|capitalize }}
+                                            {{ locale|sonata_language_name(locale)|capitalize }}
                                         </a>
                                     </li>
                                     {% endfor %}

--- a/src/Twig/Extension/IntlExtension.php
+++ b/src/Twig/Extension/IntlExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TranslationBundle\Twig\Extension;
+
+use Symfony\Component\Intl\Exception\MissingResourceException;
+use Symfony\Component\Intl\Languages;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class IntlExtension extends AbstractExtension
+{
+    /** @return TwigFilter[] */
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('sonata_language_name', [$this, 'getLanguageName']),
+        ];
+    }
+
+    /**
+     * @see https://github.com/twigphp/intl-extra/blob/v3.0.3/src/IntlExtension.php#L185
+     */
+    public function getLanguageName(string $language, string $locale): string
+    {
+        try {
+            return Languages::getName($language, $locale);
+        } catch (MissingResourceException $exception) {
+            return $language;
+        }
+    }
+}

--- a/tests/DependencyInjection/SonataTranslationExtensionTest.php
+++ b/tests/DependencyInjection/SonataTranslationExtensionTest.php
@@ -26,6 +26,24 @@ final class SonataTranslationExtensionTest extends AbstractExtensionTestCase
      *
      * @group legacy
      */
+    public function testLoadTwigIntlExtension(): void
+    {
+        $this->container->setParameter('kernel.bundles', []);
+        $this->load([
+            'locale_switcher_show_country_flags' => false,
+        ]);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'sonata_translation.twig.intl_extension',
+            'twig.extension'
+        );
+    }
+
+    /**
+     * NEXT_MAJOR: remove this annotation and corresponding deprecation notice.
+     *
+     * @group legacy
+     */
     public function testLoadServiceDefinitionWhenSonataDoctrineORMAdminBundleBundleIsRegistered(): void
     {
         $this->container->setParameter('kernel.bundles', ['SonataDoctrineORMAdminBundle' => 'whatever']);

--- a/tests/Twig/Extension/Fixtures/language_name.test
+++ b/tests/Twig/Extension/Fixtures/language_name.test
@@ -1,0 +1,12 @@
+--TEST--
+"sonata_language_name" filter
+--TEMPLATE--
+{{ 'de'|sonata_language_name('fr') }}
+{{ 'fr'|sonata_language_name('fr_FR') }}
+{{ 'fr_CA'|sonata_language_name('fr_FR') }}
+--DATA--
+return [];
+--EXPECT--
+allemand
+français
+français canadien

--- a/tests/Twig/Extension/IntlExtensionTest.php
+++ b/tests/Twig/Extension/IntlExtensionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TranslationBundle\Tests\Twig\Extension;
+
+use Sonata\TranslationBundle\Twig\Extension\IntlExtension;
+use Twig\Test\IntegrationTestCase;
+
+class IntlExtensionTest extends IntegrationTestCase
+{
+    public function getExtensions()
+    {
+        return [
+            new IntlExtension(),
+        ];
+    }
+
+    public function getFixturesDir()
+    {
+        return __DIR__.'/Fixtures/';
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

`language_name` was added, but it needed `twig/intl-extra`. I added `sonata_language_name` to avoid conflicts.

I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #335

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `sonata_language_name` Twig filter
### Fixed
- Use of undefined filter `language_name`
```

- [x] Merge https://github.com/sonata-project/SonataTranslationBundle/pull/336
