### PR TITLE
Replace usage of deprecated spaceless Twig tag with apply spaceless

### DIFF
--- a/src/Resources/views/Block/block_locale_switcher.html.twig
+++ b/src/Resources/views/Block/block_locale_switcher.html.twig
@@ -14,7 +14,7 @@
     {% endfor %}
 
     <div class="locale_switcher">
-        {% spaceless %}
+        {% apply spaceless %}
             {% for locale in sonata_translation_locales %}
                 {% if locale_switcher_route is empty %}
                     {% if object.id %}
@@ -40,6 +40,6 @@
                     {% endif %}
                 </a>
             {% endfor %}
-        {% endspaceless %}
+        {% endapply %}
     </div>
 {% endif %}


### PR DESCRIPTION
## Subject

This PR fixes the following deprecation notice:

> The spaceless tag in "@SonataTranslation/Block/block_locale_switcher.html.twig" at line 17 is deprecated since Twig 2.7, use the "spaceless" filter with the "apply" tag instead.

I am targeting this branch, because Twig 2.12 is the minimum required version of this branch.

## Changelog

```markdown
### Fixed
- Deprecation notice caused by use of spaceless tag in block_locale_switcher.html.twig.
```
