### PR TITLE
Do not invoke admin.id() with null argument

### DIFF
--- a/src/Resources/views/Block/block_locale_switcher.html.twig
+++ b/src/Resources/views/Block/block_locale_switcher.html.twig
@@ -1,11 +1,12 @@
-{% set object = block_context.settings.object %}
 {% set admin  = block_context.settings.admin %}
-{% set locale_switcher_route = block_context.settings.locale_switcher_route %}
-{% set locale_switcher_route_parameters = block_context.settings.locale_switcher_route_parameters %}
-{% set locale_switcher_show_country_flags = block_context.settings.locale_switcher_show_country_flags %}
 
 {% if admin.class is translatable %}
+    {% set object = block_context.settings.object %}
     {% set currentLocale = object.locale|default(null) %}
+    {% set object_id = object ? admin.id(object) : null %}
+    {% set locale_switcher_route = block_context.settings.locale_switcher_route|default(object_id is not null ? 'edit' : 'create') %}
+    {% set locale_switcher_route_parameters = block_context.settings.locale_switcher_route_parameters %}
+    {% set locale_switcher_show_country_flags = block_context.settings.locale_switcher_show_country_flags %}
 
     {% for extension in admin.extensions %}
         {% if extension.translatableLocale is defined %}
@@ -16,16 +17,9 @@
     <div class="locale_switcher">
         {% spaceless %}
             {% for locale in sonata_translation_locales %}
-                {% if locale_switcher_route is empty %}
-                    {% if object.id %}
-                        {% set locale_switcher_route = 'edit' %}
-                    {% else %}
-                        {% set locale_switcher_route = 'create' %}
-                    {% endif %}
-                {% endif %}
                 <a href="{{ admin.generateUrl(
                     locale_switcher_route,
-                    {'id': admin.id(object), 'tl': locale}|merge(locale_switcher_route_parameters)
+                    {'id': object_id, 'tl': locale}|merge(locale_switcher_route_parameters)
                 ) }}"
                    accesskey=""
                    {% if currentLocale == locale %}class="active"{% endif %}


### PR DESCRIPTION
## Subject

I noticed the following deprecation message in my logs:

> Passing null as argument 1 for Sonata\DoctrineORMAdminBundle\Model\ModelManager::getNormalizedIdentifier() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.20 and will be not allowed in version 4.0.

It appeared that block_locale_switcher.html.twig calls `admin.id(object)` on list pages, where object is null. I moved some code around to calculate the id only once and only if there is an object.

I also moved code that set a default value for the variable `locale_switcher_route` to outside the loop. This seems more appropriate.

I am targeting this branch, because it is a backwards compatible change.

## Changelog

```markdown
### Fixed
- Deprecation notice about ModelManager::getNormalizedIdentifier() on list pages.
```
