### PR TITLE
Bump Symfony < 4.4 and PHP < 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "sonata-project/admin-bundle": "^3.58",
         "sonata-project/block-bundle": "^3.17",
-        "symfony/config": "^4.3",
-        "symfony/dependency-injection": "^4.3",
-        "symfony/form": "^4.3",
-        "symfony/http-foundation": "^4.3",
-        "symfony/http-kernel": "^4.3",
-        "symfony/options-resolver": "^4.3",
+        "symfony/config": "^4.4",
+        "symfony/dependency-injection": "^4.4",
+        "symfony/form": "^4.4",
+        "symfony/http-foundation": "^4.4",
+        "symfony/http-kernel": "^4.4",
+        "symfony/options-resolver": "^4.4",
         "twig/twig": "^2.12"
     },
     "conflict": {
@@ -43,8 +43,8 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "sonata-project/doctrine-orm-admin-bundle": "^3.2",
         "stof/doctrine-extensions-bundle": "^1.1",
-        "symfony/framework-bundle": "^4.3.4",
-        "symfony/phpunit-bridge": "^5.0"
+        "symfony/framework-bundle": "^4.4",
+        "symfony/phpunit-bridge": "^5.1"
     },
     "suggest": {
         "doctrine/phpcr-odm": "if you translate odm documents",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Some bundles like: NotificationBundle, DoctrineORMAdminBundle, PageBundle, SeoBundle, UserBundle using Symfony v4.4. To avoid situation like [here](https://github.com/sonata-project/SonataPageBundle/issues/1168#issuecomment-655587405) some bundles like this must bump Symfony < 4.4 too.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for PHP < 7.2
- Support for Symfony < 4.4
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
