### PR TITLE
Add support for Twig 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/http-foundation": "^4.4",
         "symfony/http-kernel": "^4.4",
         "symfony/options-resolver": "^4.4",
-        "twig/twig": "^2.12"
+        "twig/twig": "^2.12 || ^3.0"
     },
     "conflict": {
         "doctrine/annotations": "<1.8",


### PR DESCRIPTION
## Subject

This PR enables Twig 3 in composer.json. There seem to be no further required changes.

I am targeting this branch, because this is a backwards compatible change.

## Changelog

```markdown
### Added
- Twig 3 compatibility.
```
