### PR TITLE
Update `UserLocaleSubscriber::onInteractiveLogin()` in order to avoid starting the session

### DIFF
--- a/src/EventSubscriber/UserLocaleSubscriber.php
+++ b/src/EventSubscriber/UserLocaleSubscriber.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\TranslationBundle\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 
@@ -26,22 +25,16 @@ use Symfony\Component\Security\Http\SecurityEvents;
  */
 final class UserLocaleSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var SessionInterface
-     */
-    private $session;
-
-    public function __construct(SessionInterface $session)
-    {
-        $this->session = $session;
-    }
-
     public function onInteractiveLogin(InteractiveLoginEvent $event)
     {
+        if (!$event->getRequest()->hasPreviousSession()) {
+            return;
+        }
+
         $user = $event->getAuthenticationToken()->getUser();
 
         if (\is_callable([$user, 'getLocale']) && null !== $user->getLocale()) {
-            $this->session->set('_locale', $user->getLocale());
+            $event->getRequest()->getSession()->set('_locale', $user->getLocale());
         }
     }
 

--- a/src/Resources/config/service_locale_switcher.xml
+++ b/src/Resources/config/service_locale_switcher.xml
@@ -10,7 +10,6 @@
             <tag name="kernel.event_subscriber"/>
         </service>
         <service id="sonata_translation.locale_switcher.user_locale_subscriber" class="%sonata_translation.locale_switcher.user_locale_subscriber.class%">
-            <argument type="service" id="session"/>
             <tag name="kernel.event_subscriber"/>
         </service>
     </services>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Update `UserLocaleSubscriber::onInteractiveLogin()` in order to avoid starting the session.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed starting the session in `UserLocaleSubscriber::onInteractiveLogin()` when there is no previous session.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
