### PR TITLE
Add support for BlockBundle 4

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,19 +1,26 @@
 UPGRADE 2.x
 ===========
 
+### Added support for sonata-project/block-bundle ^4.0
+
+If you are using `sonata-project/block-bundle`, you MUST declare explicitly the dependency with this package on your `composer.json` in order to avoid unwanted upgrades.
+
+There is a minimal BC break on `LocaleSwitcherBlockService`. If you are extending this class (keep in mind that
+it's marked as final and cannot be extended on 4.0) you SHOULD add return type declarations to `execute()` and `configureSettings()`.
+
 UPGRADE FROM 2.0 to 2.1
 =======================
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).
 
 ## Deprecated traits
 
-The `Sonata\TranslationBundle\Traits\Translatable` class is deprecated. 
+The `Sonata\TranslationBundle\Traits\Translatable` class is deprecated.
 Use `Sonata\TranslationBundle\Traits\TranslatableTrait` instead.
 
-The `Sonata\TranslationBundle\Traits\PersonalTranslatable` class is deprecated. 
+The `Sonata\TranslationBundle\Traits\PersonalTranslatable` class is deprecated.
 Use `Sonata\TranslationBundle\Traits\PersonalTranslatableTrait` instead.

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.2",
         "sonata-project/admin-bundle": "^3.58",
-        "sonata-project/block-bundle": "^3.17",
+        "sonata-project/block-bundle": "^3.17 || ^4.0",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/form": "^4.4",
@@ -44,7 +44,7 @@
         "sonata-project/doctrine-orm-admin-bundle": "^3.2",
         "stof/doctrine-extensions-bundle": "^1.1",
         "symfony/framework-bundle": "^4.4",
-        "symfony/phpunit-bridge": "^5.1"
+        "symfony/phpunit-bridge": "^5.1.1"
     },
     "suggest": {
         "doctrine/phpcr-odm": "if you translate odm documents",

--- a/src/Block/LocaleSwitcherBlockService.php
+++ b/src/Block/LocaleSwitcherBlockService.php
@@ -32,17 +32,54 @@ class LocaleSwitcherBlockService extends AbstractBlockService
     private $showCountryFlags;
 
     /**
-     * NEXT_MAJOR: Remove `$templating` argument.
+     * NEXT_MAJOR: Change signature for (Environment $twig, bool $showCountryFlags = false).
      *
      * @param Environment|string $templatingOrDeprecatedName
      */
     public function __construct(
         $templatingOrDeprecatedName = null,
-        ?EngineInterface $templating = null,
+        $showCountryFlagsOrTemplating = null,
         ?bool $showCountryFlags = false
     ) {
-        parent::__construct($templatingOrDeprecatedName, $templating);
-        $this->showCountryFlags = $showCountryFlags;
+        // NEXT_MAJOR: Uncomment the following 2 lines and remove the rest.
+        // parent::__construct($twig);
+        // $this->showCountryFlags = $showCountryFlags;
+
+        if (\is_bool($showCountryFlagsOrTemplating)) {
+            if (!$templatingOrDeprecatedName instanceof Environment) {
+                throw new \TypeError(sprintf(
+                    'Argument 1 passed to "%s()" must be an instance of "%s", %s given.',
+                    __METHOD__,
+                    Environment::class,
+                    \is_object($templatingOrDeprecatedName)
+                        ? 'instance of "'.\get_class($templatingOrDeprecatedName).'"'
+                        : '"'.\gettype($templatingOrDeprecatedName).'"'
+                ));
+            }
+
+            parent::__construct($templatingOrDeprecatedName);
+            $this->showCountryFlags = $showCountryFlagsOrTemplating;
+        } elseif (null === $showCountryFlagsOrTemplating || $showCountryFlagsOrTemplating instanceof EngineInterface) {
+            @trigger_error(sprintf(
+                'Passing "%s" as argument 2 to "%s()" is deprecated since sonata-project/translation-bundle 2.x'
+                .' and will throw a "%s" error in version 3.0. You must pass a "bool" value instead.',
+                null === $showCountryFlagsOrTemplating ? 'null' : EngineInterface::class,
+                __METHOD__,
+                \TypeError::class
+            ), E_USER_DEPRECATED);
+
+            parent::__construct($templatingOrDeprecatedName, $showCountryFlagsOrTemplating);
+            $this->showCountryFlags = $showCountryFlags;
+        } else {
+            throw new \TypeError(sprintf(
+                'Argument 2 passed to "%s()" must be either a "bool" value, "null" or an instance of "%s", %s given.',
+                __METHOD__,
+                EngineInterface::class,
+                \is_object($templatingOrDeprecatedName)
+                    ? 'instance of "'.\get_class($templatingOrDeprecatedName).'"'
+                    : '"'.\gettype($templatingOrDeprecatedName).'"'
+            ));
+        }
     }
 
     /**
@@ -55,7 +92,7 @@ class LocaleSwitcherBlockService extends AbstractBlockService
         $this->configureSettings($resolver);
     }
 
-    public function configureSettings(OptionsResolver $resolver)
+    public function configureSettings(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
             [
@@ -69,7 +106,7 @@ class LocaleSwitcherBlockService extends AbstractBlockService
         );
     }
 
-    public function execute(BlockContextInterface $blockContext, ?Response $response = null)
+    public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
     {
         return $this->renderPrivateResponse($blockContext->getTemplate(), [
             'block_context' => $blockContext,

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -7,8 +7,6 @@
         <service id="sonata_translation.block.locale_switcher" class="%sonata_translation.block.locale_switcher.class%">
             <tag name="sonata.block"/>
             <argument type="service" id="twig"/>
-            <!-- NEXT_MAJOR: Remove "null" argument -->
-            <argument>null</argument>
             <argument>%sonata_translation.locale_switcher_show_country_flags%</argument>
         </service>
     </services>

--- a/tests/Block/LocaleSwitcherBlockServiceTest.php
+++ b/tests/Block/LocaleSwitcherBlockServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TranslationBundle\Tests\Block;
+
+use Sonata\BlockBundle\Test\BlockServiceTestCase;
+use Sonata\TranslationBundle\Block\LocaleSwitcherBlockService;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Twig\Environment;
+
+final class LocaleSwitcherBlockServiceTest extends BlockServiceTestCase
+{
+    use ExpectDeprecationTrait;
+
+    public function testDefaultSettings(): void
+    {
+        $environment = $this->createStub(Environment::class);
+
+        $showCountryFlags = true;
+        $localeSwitcherBlock = new LocaleSwitcherBlockService($environment, $showCountryFlags);
+
+        $blockContext = $this->getBlockContext($localeSwitcherBlock);
+
+        $this->assertSettings([
+            'admin' => null,
+            'object' => null,
+            'template' => '@SonataTranslation/Block/block_locale_switcher.html.twig',
+            'locale_switcher_route' => null,
+            'locale_switcher_route_parameters' => [],
+            'locale_switcher_show_country_flags' => $showCountryFlags,
+        ], $blockContext);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testDefaultSettingsWithWrongConstructor(): void
+    {
+        $this->expectException(\TypeError::class);
+        new LocaleSwitcherBlockService($this->createStub(Environment::class), new \stdClass());
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testDefaultSettingsWithDeprecatedConstructor(): void
+    {
+        $environment = $this->createStub(Environment::class);
+
+        $showCountryFlags = true;
+        $this->expectDeprecation(
+            'Passing "null" as argument 2 to "Sonata\TranslationBundle\Block\LocaleSwitcherBlockService::__construct()"'
+            .' is deprecated since sonata-project/translation-bundle 2.x and will throw a "TypeError" error in version 3.0.'
+            .' You must pass a "bool" value instead.'
+        );
+        $localeSwitcherBlock = new LocaleSwitcherBlockService($environment, null, $showCountryFlags);
+
+        $blockContext = $this->getBlockContext($localeSwitcherBlock);
+
+        $this->assertSettings([
+            'admin' => null,
+            'object' => null,
+            'template' => '@SonataTranslation/Block/block_locale_switcher.html.twig',
+            'locale_switcher_route' => null,
+            'locale_switcher_route_parameters' => [],
+            'locale_switcher_show_country_flags' => $showCountryFlags,
+        ], $blockContext);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it would be nice to have support of BlockBundle 4.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add support for SonataBlockBundle 4.0
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
