### PR TITLE
Add PHPStan check

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,14 @@
+on: [push, pull_request]
+name: Quality assurance
+jobs:
+    phpstan:
+        name: PHPStan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: PHPStan
+              uses: "docker://oskarstark/phpstan-ga"
+              env:
+                  REQUIRE_DEV: true
+              with:
+                  args: analyse

--- a/composer.json
+++ b/composer.json
@@ -39,12 +39,16 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.5",
+        "doctrine/phpcr-odm": "^1.5",
+        "jackalope/jackalope-doctrine-dbal": "^1.5",
         "knplabs/doctrine-behaviors": "^1.4",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
+        "phpstan/phpstan": "^0.12.48",
         "sonata-project/doctrine-orm-admin-bundle": "^3.2",
         "stof/doctrine-extensions-bundle": "^1.1",
         "symfony/framework-bundle": "^4.4",
-        "symfony/phpunit-bridge": "^5.1.1"
+        "symfony/phpunit-bridge": "^5.1.1",
+        "symfony/templating": "^4.4 || ^5.1"
     },
     "suggest": {
         "doctrine/phpcr-odm": "if you translate odm documents",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+parameters:
+    level: 1
+
+    paths:
+        - src
+
+    excludes_analyse:
+        - src/Test/DoctrineOrmTestCase.php

--- a/src/Admin/Extension/AbstractTranslatableAdminExtension.php
+++ b/src/Admin/Extension/AbstractTranslatableAdminExtension.php
@@ -16,6 +16,7 @@ namespace Sonata\TranslationBundle\Admin\Extension;
 use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>


### PR DESCRIPTION
I've added some packages to require-dev as they were errors because classes didn't exist.

- [x] [dev-kit PR adding phpstan](https://github.com/sonata-project/dev-kit/pull/1149)