### PR TITLE
Allow knplabs/doctrine-behaviors 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,14 +36,14 @@
         "doctrine/persistence": "<1.3.4",
         "doctrine/phpcr-odm": ">=3.0",
         "gedmo/doctrine-extensions": "<2.4.36",
-        "knplabs/doctrine-behaviors": "<1.0 || >=2.0",
+        "knplabs/doctrine-behaviors": "<1.0 || >=3.0",
         "stof/doctrine-extensions-bundle": "<1.1 || >=2.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.5",
         "doctrine/phpcr-odm": "^1.5",
         "jackalope/jackalope-doctrine-dbal": "^1.5",
-        "knplabs/doctrine-behaviors": "^1.4",
+        "knplabs/doctrine-behaviors": "^1.4 || ^2.0",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "phpstan/extension-installer": "^1.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -38,13 +38,6 @@ parameters:
             count: 1
             path: tests/Block/LocaleSwitcherBlockServiceTest.php
 
-        # This will be resolved when knplabs/doctrine-behaviors 2 is used
-
-        -
-            message: "#^Method Sonata\\\\TranslationBundle\\\\Tests\\\\Fixtures\\\\Model\\\\Knplabs\\\\TranslatableEntity\\:\\:getLocale\\(\\) should return string but returns Knp\\\\DoctrineBehaviors\\\\Model\\\\Translatable\\\\Returns\\.$#"
-            count: 1
-            path: tests/Fixtures/Model/Knplabs/TranslatableEntity.php
-
         # Symfony issue
 
         -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,3 +10,7 @@ parameters:
 
     excludes_analyse:
         - src/Test/DoctrineOrmTestCase.php
+        # Remove these lines when dropping support for KnpLabs/DoctrineBehaviors < 2.0
+        - tests/Fixtures/Model/Knplabs/TranslatableEntity.php
+        - tests/Fixtures/Model/Knplabs/TranslatableEntityTranslation.php
+        - tests/Fixtures/Traits/ORM/Knplabs/ArticleTranslation.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -24,16 +24,4 @@
             <code>children</code>
         </PossiblyUndefinedMethod>
     </file>
-    <!-- This will be resolved when knplabs/doctrine-behaviors 2 is used -->
-    <file src="tests/Fixtures/Model/Knplabs/TranslatableEntity.php">
-        <InvalidReturnStatement occurrences="1">
-            <code>$this-&gt;getCurrentLocale()</code>
-        </InvalidReturnStatement>
-        <InvalidReturnType occurrences="1">
-            <code>getLocale</code>
-        </InvalidReturnType>
-        <UndefinedDocblockClass occurrences="1">
-            <code>$this-&gt;getCurrentLocale()</code>
-        </UndefinedDocblockClass>
-    </file>
 </files>

--- a/tests/Fixtures/Model/Knplabs/TranslatableEntity.php
+++ b/tests/Fixtures/Model/Knplabs/TranslatableEntity.php
@@ -2,30 +2,60 @@
 
 namespace Sonata\TranslationBundle\Tests\Fixtures\Model\Knplabs;
 
-use Knp\DoctrineBehaviors\Model;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface as KNPTranslatableInterface;
+use Knp\DoctrineBehaviors\Model\Translatable\Translatable;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 use Sonata\TranslationBundle\Model\TranslatableInterface;
 
-class TranslatableEntity implements TranslatableInterface
-{
-    use Model\Translatable\Translatable;
-
-    /**
-     * @var int|null
-     */
-    private $id;
-
-    public function getId(): ?int
+// @todo Remove check and else part when dropping support for knplabs/doctrine-behaviors < 2.0
+if (interface_exists(KNPTranslatableInterface::class)) {
+    class TranslatableEntity implements TranslatableInterface, KNPTranslatableInterface
     {
-        return $this->id;
+        use TranslatableTrait;
+
+        /**
+         * @var int|null
+         */
+        private $id;
+
+        public function getId(): ?int
+        {
+            return $this->id;
+        }
+
+        public function setLocale($locale)
+        {
+            $this->setCurrentLocale($locale);
+        }
+
+        public function getLocale()
+        {
+            return $this->getCurrentLocale();
+        }
     }
-
-    public function setLocale($locale)
+} else {
+    class TranslatableEntity implements TranslatableInterface
     {
-        $this->setCurrentLocale($locale);
-    }
+        use Translatable;
 
-    public function getLocale()
-    {
-        return $this->getCurrentLocale();
+        /**
+         * @var int|null
+         */
+        private $id;
+
+        public function getId(): ?int
+        {
+            return $this->id;
+        }
+
+        public function setLocale($locale)
+        {
+            $this->setCurrentLocale($locale);
+        }
+
+        public function getLocale()
+        {
+            return $this->getCurrentLocale();
+        }
     }
 }

--- a/tests/Fixtures/Model/Knplabs/TranslatableEntityTranslation.php
+++ b/tests/Fixtures/Model/Knplabs/TranslatableEntityTranslation.php
@@ -1,25 +1,50 @@
 <?php
 
-namespace Sonata\TranslationBundle\Tests\Functional\Fixtures\Model\Knplabs;
+namespace Sonata\TranslationBundle\Tests\Fixtures\Model\Knplabs;
 
-use Knp\DoctrineBehaviors\Model;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
+use Knp\DoctrineBehaviors\Model\Translatable\Translation;
 
-class TranslatableEntityTranslation
-{
-    use Model\Translatable\Translation;
-
-    /**
-     * @var string|null
-     */
-    private $title;
-
-    public function getTitle(): ?string
+// @todo Remove check and else part when dropping support for knplabs/doctrine-behaviors < 2.0
+if (interface_exists(TranslationInterface::class)) {
+    class TranslatableEntityTranslation implements TranslationInterface
     {
-        return $this->title;
+        use TranslationTrait;
+
+        /**
+         * @var string|null
+         */
+        private $title;
+
+        public function getTitle(): ?string
+        {
+            return $this->title;
+        }
+
+        public function setTitle(string $title): void
+        {
+            $this->title = $title;
+        }
     }
-
-    public function setTitle(string $title): void
+} else {
+    class TranslatableEntityTranslation
     {
-        $this->title = $title;
+        use Translation;
+
+        /**
+         * @var string|null
+         */
+        private $title;
+
+        public function getTitle(): ?string
+        {
+            return $this->title;
+        }
+
+        public function setTitle(string $title): void
+        {
+            $this->title = $title;
+        }
     }
 }

--- a/tests/Fixtures/Traits/ORM/Knplabs/AbstractArticleTranslation.php
+++ b/tests/Fixtures/Traits/ORM/Knplabs/AbstractArticleTranslation.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\Knplabs;
+
+use Doctrine\ORM\Mapping as ORM;
+
+abstract class AbstractArticleTranslation
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @var Article|null
+     *
+     * @ORM\ManyToOne(
+     *     targetEntity="Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\Knplabs\ArticleTranslation",
+     *     inversedBy="translations",
+     *     cascade={"persist", "merge"}
+     * )
+     * @ORM\JoinColumn(name="translatable_id", referencedColumnName="id", onDelete="CASCADE")
+     */
+    protected $translatable;
+
+    /**
+     * @ORM\Column(length=128)
+     *
+     * @var string|null
+     */
+    protected $title;
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/tests/Fixtures/Traits/ORM/Knplabs/ArticleTranslation.php
+++ b/tests/Fixtures/Traits/ORM/Knplabs/ArticleTranslation.php
@@ -3,56 +3,37 @@
 namespace Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\Knplabs;
 
 use Doctrine\ORM\Mapping as ORM;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 use Knp\DoctrineBehaviors\Model\Translatable\Translation;
 
-/**
- * @ORM\Table(name="article_translation")
- * @ORM\Entity
- */
-final class ArticleTranslation
-{
-    use Translation;
-
+// @todo Remove check and else part when dropping support for knplabs/doctrine-behaviors < 2.0
+if (interface_exists(TranslationInterface::class)) {
     /**
-     * @var int|null
-     *
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
+     * @ORM\Table(name="article_translation")
+     * @ORM\Entity
      */
-    protected $id;
-
-    /**
-     * @var Article|null
-     *
-     * @ORM\ManyToOne(
-     *     targetEntity="Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\Knplabs\ArticleTranslation",
-     *     inversedBy="translations",
-     *     cascade={"persist", "merge"}
-     * )
-     * @ORM\JoinColumn(name="translatable_id", referencedColumnName="id", onDelete="CASCADE")
-     */
-    protected $translatable;
-
-    /**
-     * @ORM\Column(length=128)
-     *
-     * @var string|null
-     */
-    protected $title;
-
-    public function getTitle(): ?string
+    final class ArticleTranslation extends AbstractArticleTranslation implements TranslationInterface
     {
-        return $this->title;
+        use TranslationTrait;
+
+        public static function getTranslatableEntityClass(): string
+        {
+            return Article::class;
+        }
     }
-
-    public function setTitle(string $title): void
+} else {
+    /**
+     * @ORM\Table(name="article_translation")
+     * @ORM\Entity
+     */
+    final class ArticleTranslation extends AbstractArticleTranslation
     {
-        $this->title = $title;
-    }
+        use Translation;
 
-    public static function getTranslatableEntityClass(): string
-    {
-        return Article::class;
+        public static function getTranslatableEntityClass(): string
+        {
+            return Article::class;
+        }
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Allows to install knplabs/doctrine-behaviors 2, apparently it introduced some interfaces.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for `knplabs/doctrine-behaviors` 2.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
