### PR TITLE
Use Psalm with symfony phpunit bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
         "phpstan/phpstan-doctrine": "^0.12.26",
         "phpstan/phpstan-phpunit": "^0.12.16",
         "phpstan/phpstan-symfony": "^0.12.11",
-        "phpunit/phpunit": "^9.4.0",
         "psalm/plugin-phpunit": "^0.15.0",
         "psalm/plugin-symfony": "^2.0",
         "sonata-project/doctrine-orm-admin-bundle": "^3.2",
@@ -85,5 +84,13 @@
         "psr-4": {
             "Sonata\\TranslationBundle\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "[ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/simple-phpunit install"
+        ],
+        "post-update-cmd": [
+            "[ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/simple-phpunit install"
+        ]
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,9 @@ includes:
 parameters:
     level: 6
 
+    bootstrapFiles:
+        - vendor/bin/.phpunit/phpunit/vendor/autoload.php
+
     paths:
         - src
         - tests

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6,7 +6,7 @@
             <code>getDocumentManager</code>
         </UndefinedInterfaceMethod>
     </file>
-    <!-- NEXT_MAJOR: Remove this file configuration -->
+    <!-- NEXT_MAJOR: Remove these errors -->
     <file src="src/Block/LocaleSwitcherBlockService.php">
         <PossiblyInvalidArgument occurrences="1">
             <code>$templatingOrDeprecatedName</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" errorLevel="3" resolveFromConfigFile="true" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd" errorBaseline="psalm-baseline.xml">
+<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd" autoloader="vendor/bin/.phpunit/phpunit/vendor/autoload.php" errorBaseline="psalm-baseline.xml" errorLevel="3">
     <projectFiles>
         <directory name="src"/>
         <directory name="tests"/>


### PR DESCRIPTION
Pedantic ; solve https://github.com/sonata-project/SonataTranslationBundle/pull/418#discussion_r521906888

To use the psalm phpunit plugin without requiring `phpunit/phpunit`, it required the last version of the plugin, which is only compatible with psalm 4. But the psalm doctrine plugin is currently not compatible with psalm 4.
