### PR TITLE
Drop support of knplabs/doctrine-behaviors <2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "conflict": {
         "doctrine/annotations": "<1.8",
-        "doctrine/persistence": "<1.3.4",
+        "doctrine/persistence": "<2.0",
         "doctrine/phpcr-odm": ">=3.0",
         "gedmo/doctrine-extensions": "<2.4.36",
         "knplabs/doctrine-behaviors": "<2.0 || >=3.0",
@@ -41,6 +41,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.5",
+        "doctrine/persistence": "^2.0",
         "doctrine/phpcr-odm": "^1.5",
         "gedmo/doctrine-extensions": "^2.3.36 || ^3.0",
         "jackalope/jackalope-doctrine-dbal": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "doctrine/persistence": "<1.3.4",
         "doctrine/phpcr-odm": ">=3.0",
         "gedmo/doctrine-extensions": "<2.4.36",
-        "knplabs/doctrine-behaviors": "<1.0 || >=3.0",
+        "knplabs/doctrine-behaviors": "<2.0 || >=3.0",
         "sonata-project/doctrine-orm-admin-bundle": "<4.0"
     },
     "require-dev": {
@@ -44,7 +44,7 @@
         "doctrine/phpcr-odm": "^1.5",
         "gedmo/doctrine-extensions": "^2.3.36 || ^3.0",
         "jackalope/jackalope-doctrine-dbal": "^1.5",
-        "knplabs/doctrine-behaviors": "^1.4 || ^2.0",
+        "knplabs/doctrine-behaviors": "^2.0",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "phpstan/extension-installer": "^1.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,3 @@ parameters:
     paths:
         - src
         - tests
-
-    excludes_analyse:
-        - src/Test/DoctrineOrmTestCase.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,7 +13,3 @@ parameters:
 
     excludes_analyse:
         - src/Test/DoctrineOrmTestCase.php
-        # Remove these lines when dropping support for KnpLabs/DoctrineBehaviors < 2.0
-        - tests/Fixtures/Model/Knplabs/TranslatableEntity.php
-        - tests/Fixtures/Model/Knplabs/TranslatableEntityTranslation.php
-        - tests/Fixtures/Traits/ORM/Knplabs/ArticleTranslation.php

--- a/tests/Fixtures/Model/Knplabs/TranslatableEntity.php
+++ b/tests/Fixtures/Model/Knplabs/TranslatableEntity.php
@@ -14,59 +14,30 @@ declare(strict_types=1);
 namespace Sonata\TranslationBundle\Tests\Fixtures\Model\Knplabs;
 
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface as KNPTranslatableInterface;
-use Knp\DoctrineBehaviors\Model\Translatable\Translatable;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 use Sonata\TranslationBundle\Model\TranslatableInterface;
 
-// @todo Remove check and else part when dropping support for knplabs/doctrine-behaviors < 2.0
-if (interface_exists(KNPTranslatableInterface::class)) {
-    class TranslatableEntity implements TranslatableInterface, KNPTranslatableInterface
+class TranslatableEntity implements TranslatableInterface, KNPTranslatableInterface
+{
+    use TranslatableTrait;
+
+    /**
+     * @var int|null
+     */
+    private $id;
+
+    public function getId(): ?int
     {
-        use TranslatableTrait;
-
-        /**
-         * @var int|null
-         */
-        private $id;
-
-        public function getId(): ?int
-        {
-            return $this->id;
-        }
-
-        public function setLocale($locale): void
-        {
-            $this->setCurrentLocale($locale);
-        }
-
-        public function getLocale(): string
-        {
-            return $this->getCurrentLocale();
-        }
+        return $this->id;
     }
-} else {
-    class TranslatableEntity implements TranslatableInterface
+
+    public function setLocale($locale): void
     {
-        use Translatable;
+        $this->setCurrentLocale($locale);
+    }
 
-        /**
-         * @var int|null
-         */
-        private $id;
-
-        public function getId(): ?int
-        {
-            return $this->id;
-        }
-
-        public function setLocale($locale): void
-        {
-            $this->setCurrentLocale($locale);
-        }
-
-        public function getLocale(): string
-        {
-            return $this->getCurrentLocale();
-        }
+    public function getLocale(): string
+    {
+        return $this->getCurrentLocale();
     }
 }

--- a/tests/Fixtures/Model/Knplabs/TranslatableEntityTranslation.php
+++ b/tests/Fixtures/Model/Knplabs/TranslatableEntityTranslation.php
@@ -14,48 +14,24 @@ declare(strict_types=1);
 namespace Sonata\TranslationBundle\Tests\Fixtures\Model\Knplabs;
 
 use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
-use Knp\DoctrineBehaviors\Model\Translatable\Translation;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 
-// @todo Remove check and else part when dropping support for knplabs/doctrine-behaviors < 2.0
-if (interface_exists(TranslationInterface::class)) {
-    class TranslatableEntityTranslation implements TranslationInterface
+class TranslatableEntityTranslation implements TranslationInterface
+{
+    use TranslationTrait;
+
+    /**
+     * @var string|null
+     */
+    private $title;
+
+    public function getTitle(): ?string
     {
-        use TranslationTrait;
-
-        /**
-         * @var string|null
-         */
-        private $title;
-
-        public function getTitle(): ?string
-        {
-            return $this->title;
-        }
-
-        public function setTitle(string $title): void
-        {
-            $this->title = $title;
-        }
+        return $this->title;
     }
-} else {
-    class TranslatableEntityTranslation
+
+    public function setTitle(string $title): void
     {
-        use Translation;
-
-        /**
-         * @var string|null
-         */
-        private $title;
-
-        public function getTitle(): ?string
-        {
-            return $this->title;
-        }
-
-        public function setTitle(string $title): void
-        {
-            $this->title = $title;
-        }
+        $this->title = $title;
     }
 }

--- a/tests/Fixtures/Traits/ORM/Knplabs/ArticleTranslation.php
+++ b/tests/Fixtures/Traits/ORM/Knplabs/ArticleTranslation.php
@@ -15,36 +15,18 @@ namespace Sonata\TranslationBundle\Tests\Fixtures\Traits\ORM\Knplabs;
 
 use Doctrine\ORM\Mapping as ORM;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
-use Knp\DoctrineBehaviors\Model\Translatable\Translation;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 
-// @todo Remove check and else part when dropping support for knplabs/doctrine-behaviors < 2.0
-if (interface_exists(TranslationInterface::class)) {
-    /**
-     * @ORM\Table(name="article_translation")
-     * @ORM\Entity
-     */
-    final class ArticleTranslation extends AbstractArticleTranslation implements TranslationInterface
-    {
-        use TranslationTrait;
+/**
+ * @ORM\Table(name="article_translation")
+ * @ORM\Entity
+ */
+final class ArticleTranslation extends AbstractArticleTranslation implements TranslationInterface
+{
+    use TranslationTrait;
 
-        public static function getTranslatableEntityClass(): string
-        {
-            return Article::class;
-        }
-    }
-} else {
-    /**
-     * @ORM\Table(name="article_translation")
-     * @ORM\Entity
-     */
-    final class ArticleTranslation extends AbstractArticleTranslation
+    public static function getTranslatableEntityClass(): string
     {
-        use Translation;
-
-        public static function getTranslatableEntityClass(): string
-        {
-            return Article::class;
-        }
+        return Article::class;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

`kplabs/doctrine-behaviours` 2.0 was release more than one year ago: https://github.com/KnpLabs/DoctrineBehaviors/releases/tag/v2.0.0

`gedmo/doctrine-extensions` 3.0 was released 7 months ago: https://github.com/doctrine-extensions/DoctrineExtensions/releases/tag/v3.0.0 IMO we can also drop support for 2.x.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed support for `knplabs/doctrine-behaviors` < 2.0
- Removed support for `doctrine/persistence` < 2.0
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
