### PR TITLE
Set locale properly from the admin

### DIFF
--- a/src/Admin/Extension/AbstractTranslatableAdminExtension.php
+++ b/src/Admin/Extension/AbstractTranslatableAdminExtension.php
@@ -70,12 +70,7 @@ abstract class AbstractTranslatableAdminExtension extends AbstractAdminExtension
     public function getTranslatableLocale(AdminInterface $admin): string
     {
         if (null === $this->translatableLocale) {
-            if ($admin->hasRequest()) {
-                $this->translatableLocale = (string) $admin->getRequest()->get(self::TRANSLATABLE_LOCALE_PARAMETER);
-            }
-            if (null === $this->translatableLocale) {
-                $this->translatableLocale = $this->defaultTranslationLocale;
-            }
+            $this->translatableLocale = $this->getLocaleFromAdmin($admin);
         }
 
         return $this->translatableLocale;
@@ -93,5 +88,23 @@ abstract class AbstractTranslatableAdminExtension extends AbstractAdminExtension
         if (null === $object->getLocale()) {
             $object->setLocale($this->getTranslatableLocale($admin));
         }
+    }
+
+    /**
+     * @phpstan-param AdminInterface<TranslatableInterface> $admin
+     */
+    private function getLocaleFromAdmin(AdminInterface $admin): string
+    {
+        if (!$admin->hasRequest()) {
+            return $this->defaultTranslationLocale;
+        }
+
+        $locale = (string) $admin->getRequest()->get(self::TRANSLATABLE_LOCALE_PARAMETER);
+
+        if ('' !== $locale) {
+            return $locale;
+        }
+
+        return $this->defaultTranslationLocale;
     }
 }

--- a/tests/Admin/Extension/AbstractTranslatableAdminExtensionTest.php
+++ b/tests/Admin/Extension/AbstractTranslatableAdminExtensionTest.php
@@ -18,13 +18,10 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\TranslationBundle\Admin\Extension\AbstractTranslatableAdminExtension;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\Model\TranslatableInterface;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\Request;
 
 final class AbstractTranslatableAdminExtensionTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @var AbstractTranslatableAdminExtension
      */

--- a/tests/Admin/Extension/AbstractTranslatableAdminExtensionTest.php
+++ b/tests/Admin/Extension/AbstractTranslatableAdminExtensionTest.php
@@ -39,8 +39,7 @@ final class AbstractTranslatableAdminExtensionTest extends TestCase
             TranslatableInterface::class,
         ]);
 
-        $this->extension = new class($this->translatableChecker, 'es') extends AbstractTranslatableAdminExtension {
-        };
+        $this->extension = new class($this->translatableChecker, 'en') extends AbstractTranslatableAdminExtension {};
     }
 
     public function testGetTranslatableLocaleFromRequest(): void
@@ -56,12 +55,24 @@ final class AbstractTranslatableAdminExtensionTest extends TestCase
         $this->assertSame('es', $this->extension->getTranslatableLocale($admin));
     }
 
+    public function testGetTranslatableLocaleFromDefaultWithRequestWithNoLocale(): void
+    {
+        $request = new Request();
+
+        $admin = $this->createStub(AdminInterface::class);
+
+        $admin->method('getRequest')->willReturn($request);
+        $admin->method('hasRequest')->willReturn(true);
+
+        $this->assertSame('en', $this->extension->getTranslatableLocale($admin));
+    }
+
     public function testGetTranslatableLocaleFromDefault(): void
     {
         $admin = $this->createStub(AdminInterface::class);
 
         $admin->method('hasRequest')->willReturn(false);
 
-        $this->assertSame('es', $this->extension->getTranslatableLocale($admin));
+        $this->assertSame('en', $this->extension->getTranslatableLocale($admin));
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There was this code:
```php
if ($admin->hasRequest()) {
    $this->translatableLocale = (string) $admin->getRequest()->get(self::TRANSLATABLE_LOCALE_PARAMETER);
}

if (null === $this->translatableLocale) {
    $this->translatableLocale = $this->defaultTranslationLocale;
}
```

if there was request, but no parameter, `$this->translatableLocale` was set to an empty string instead of the default locale.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the casting was introduced in this branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->