### PR TITLE
Fix service reference

### DIFF
--- a/src/DependencyInjection/SonataTranslationExtension.php
+++ b/src/DependencyInjection/SonataTranslationExtension.php
@@ -21,6 +21,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -181,7 +182,7 @@ class SonataTranslationExtension extends Extension
         // Registration based on the documentation
         // see https://github.com/doctrine-extensions/DoctrineExtensions/blob/7c0d5aeab0f840d2a18a18c3dc10b0117c597a42/doc/symfony4.md#doctrine-extension-listener-services
         $container->register('sonata_translation.listener.translatable', TranslatableListener::class)
-            ->addMethodCall('setAnnotationReader', ['@annotation_reader'])
+            ->addMethodCall('setAnnotationReader', [new Reference('annotation_reader')])
             ->addMethodCall('setDefaultLocale', ['%locale%'])
             ->addMethodCall('setTranslationFallback', [false])
             ->addTag('doctrine.event_subscriber');

--- a/tests/DependencyInjection/SonataTranslationExtensionTest.php
+++ b/tests/DependencyInjection/SonataTranslationExtensionTest.php
@@ -18,6 +18,7 @@ use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\DependencyInjection\SonataTranslationExtension;
 use Sonata\TranslationBundle\Filter\TranslationFieldFilter;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
@@ -113,6 +114,12 @@ final class SonataTranslationExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService(
             'sonata_translation.listener.translatable',
             TranslatableListener::class
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata_translation.listener.translatable',
+            'setAnnotationReader',
+            [new Reference('annotation_reader')]
         );
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The argument passed to the `setAnnotationReader` method was a string instead of a reference to a service.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed registering `sonata_translation.listener.translatable` when no `translatable_listener_service` is defined
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
