### PR TITLE
Explicitly require symfony/intl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/form": "^4.4",
         "symfony/http-foundation": "^4.4",
         "symfony/http-kernel": "^4.4",
+        "symfony/intl": "^4.4",
         "symfony/options-resolver": "^4.4",
         "twig/twig": "^2.12 || ^3.0"
     },


### PR DESCRIPTION
It is used in https://github.com/sonata-project/SonataTranslationBundle/blob/a7e5eb022f6b915ef878e3ae3a54b17c55e56356/src/Twig/Extension/IntlExtension.php#L16-L17

I've labeled as _pedantic_ since there is no problem using it with Symfony 4 (`symfony/form` requires it).