### PR TITLE
Make compiler passes internal and minor tweaks

### DIFF
--- a/src/Admin/Extension/AbstractTranslatableAdminExtension.php
+++ b/src/Admin/Extension/AbstractTranslatableAdminExtension.php
@@ -22,6 +22,8 @@ use Sonata\TranslationBundle\Model\TranslatableInterface;
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  *
  * @phpstan-extends AbstractAdminExtension<TranslatableInterface>
+ *
+ * @internal
  */
 abstract class AbstractTranslatableAdminExtension extends AbstractAdminExtension
 {

--- a/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Nicolas Bastien <nbastien@prestaconcept.net>
+ *
+ * @internal
  */
 final class AdminExtensionCompilerPass implements CompilerPassInterface
 {

--- a/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
@@ -18,6 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
+ *
+ * @internal
  */
 final class GlobalVariablesCompilerPass implements CompilerPassInterface
 {

--- a/src/Filter/TranslationFieldFilter.php
+++ b/src/Filter/TranslationFieldFilter.php
@@ -16,7 +16,6 @@ namespace Sonata\TranslationBundle\Filter;
 use Doctrine\ORM\Query\Expr\Join;
 use Sonata\AdminBundle\Filter\Model\FilterData;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
-use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\DoctrineORMAdminBundle\Filter\Filter;
 use Sonata\TranslationBundle\Enum\TranslationFilterMode;
@@ -43,13 +42,11 @@ final class TranslationFieldFilter extends Filter
 
         $value = trim((string) $data->getValue());
 
-        if (0 === \strlen($value)) {
+        if ('' === $value) {
             return;
         }
         $joinAlias = 'tff';
         $filterMode = (string) $this->getOption('filter_mode');
-
-        \assert($query instanceof ProxyQuery);
 
         // verify if the join is not already done
         $aliasAlreadyExists = false;

--- a/src/Model/TranslatableInterface.php
+++ b/src/Model/TranslatableInterface.php
@@ -18,15 +18,7 @@ namespace Sonata\TranslationBundle\Model;
  */
 interface TranslatableInterface
 {
-    /**
-     * @param string $locale
-     *
-     * @return void
-     */
-    public function setLocale($locale);
+    public function setLocale(string $locale): void;
 
-    /**
-     * @return string|null
-     */
-    public function getLocale();
+    public function getLocale(): ?string;
 }

--- a/src/Twig/Extension/SonataTranslationExtension.php
+++ b/src/Twig/Extension/SonataTranslationExtension.php
@@ -34,11 +34,6 @@ final class SonataTranslationExtension extends AbstractExtension
         $this->translatableChecker = $translatableChecker;
     }
 
-    public function getName(): string
-    {
-        return 'sonata_translation';
-    }
-
     public function setTranslatableChecker(TranslatableChecker $translatableChecker): void
     {
         $this->translatableChecker = $translatableChecker;

--- a/tests/Admin/Extension/AbstractTranslatableAdminExtensionTest.php
+++ b/tests/Admin/Extension/AbstractTranslatableAdminExtensionTest.php
@@ -32,6 +32,9 @@ final class AbstractTranslatableAdminExtensionTest extends TestCase
      */
     private $translatableChecker;
 
+    /**
+     * @psalm-suppress InternalClass https://github.com/vimeo/psalm/issues/6315
+     */
     protected function setUp(): void
     {
         $this->translatableChecker = new TranslatableChecker();

--- a/tests/Fixtures/Model/Knplabs/TranslatableEntity.php
+++ b/tests/Fixtures/Model/Knplabs/TranslatableEntity.php
@@ -31,7 +31,7 @@ class TranslatableEntity implements TranslatableInterface, KNPTranslatableInterf
         return $this->id;
     }
 
-    public function setLocale($locale): void
+    public function setLocale(string $locale): void
     {
         $this->setCurrentLocale($locale);
     }

--- a/tests/Fixtures/Model/ModelTranslatable.php
+++ b/tests/Fixtures/Model/ModelTranslatable.php
@@ -25,18 +25,12 @@ class ModelTranslatable implements TranslatableInterface
      */
     private $locale;
 
-    /**
-     * @param string $locale
-     */
-    public function setLocale($locale): void
+    public function setLocale(string $locale): void
     {
         $this->locale = $locale;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getLocale()
+    public function getLocale(): ?string
     {
         return $this->locale;
     }


### PR DESCRIPTION
I think with these changes we can release a RC.

~I was thinking about deprecating the abstract classes from https://github.com/sonata-project/SonataTranslationBundle/tree/master/src/Model since I don't think users should extend their models from this bundle, in any case these models should be provided by the library (this can be also deprecated in `3.x`).~ Done in https://github.com/sonata-project/SonataTranslationBundle/pull/537

I am targeting this branch, because removing method is BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed compiler passes as internal
- AbstractTranslatableAdminExtension is now `@internal`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
