### PR TITLE
Deprecate abstract classes and traits for translatable models

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -26,6 +26,19 @@ sonata_translation:
         translatable_listener_service: stof_doctrine_extensions.listener.translatable
 ```
 
+### Deprecated abstract models and traits
+
+- `Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslatable`.
+- `Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation`.
+- `Sonata\TranslationBundle\Model\Gedmo\AbstractTranslatable`.
+- `Sonata\TranslationBundle\Model\AbstractTranslatable`.
+- `Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatableTrait`.
+- `Sonata\TranslationBundle\Traits\Gedmo\TranslatableTrait`.
+- `Sonata\TranslationBundle\Traits\TranslatableTrait`.
+
+All abstract models and traits for translatable models have been deprecated without replacement, you should create
+your own.
+
 UPGRADE FROM 2.1 to 2.7
 =======================
 

--- a/src/Checker/TranslatableChecker.php
+++ b/src/Checker/TranslatableChecker.php
@@ -95,20 +95,6 @@ class TranslatableChecker
             return false;
         }
 
-        // NEXT_MAJOR: remove Translateable and PersonalTrait.
-        $translateTraits = [
-            Translatable::class,
-            TranslatableTrait::class,
-            PersonalTranslatable::class,
-            PersonalTranslatableTrait::class,
-        ];
-
-        $traits = class_uses($object);
-        \assert(\is_array($traits));
-        if (\count(array_intersect($translateTraits, $traits)) > 0) {
-            return true;
-        }
-
         $objectInterfaces = class_implements($object);
         \assert(\is_array($objectInterfaces));
         foreach ($this->getSupportedInterfaces() as $interface) {
@@ -121,6 +107,28 @@ class TranslatableChecker
             if ($object instanceof $model) {
                 return true;
             }
+        }
+
+        // NEXT_MAJOR: remove Translateable and PersonalTrait.
+        $translateTraits = [
+            Translatable::class,
+            TranslatableTrait::class,
+            PersonalTranslatable::class,
+            PersonalTranslatableTrait::class,
+        ];
+
+        $traits = class_uses($object);
+        \assert(\is_array($traits));
+        if (\count(array_intersect($translateTraits, $traits)) > 0) {
+            @trigger_error(sprintf(
+                'Using traits to specify that a model is translatable is deprecated since'
+                .' sonata-project/translation-bundle 2.x and will be not possible in version 3.0. To mark "%s" class'
+                .' as translatable you should implement one of "%s" interfaces.',
+                \is_string($object) ? $object : \get_class($object),
+                implode(', ', $this->getSupportedInterfaces())
+            ), \E_USER_DEPRECATED);
+
+            return true;
         }
 
         return false;

--- a/src/Model/AbstractTranslatable.php
+++ b/src/Model/AbstractTranslatable.php
@@ -14,9 +14,13 @@ declare(strict_types=1);
 namespace Sonata\TranslationBundle\Model;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * If you don't want to extend this class, you can use Translatable trait instead.
  *
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
+ *
+ * @deprecated since version 2.x, to be removed in 3.0.
  */
 abstract class AbstractTranslatable
 {

--- a/src/Model/Gedmo/AbstractPersonalTranslatable.php
+++ b/src/Model/Gedmo/AbstractPersonalTranslatable.php
@@ -17,11 +17,14 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * This is your base class if you want to use gedmo personal translation
  * ie: if you want to have a dedicated translation table by model table.
  *
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  *
+ * @deprecated since version 2.x, to be removed in 3.0. Create your own instead.
  * @see https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/translatable.md : Personal translations
  */
 abstract class AbstractPersonalTranslatable extends AbstractTranslatable

--- a/src/Model/Gedmo/AbstractPersonalTranslation.php
+++ b/src/Model/Gedmo/AbstractPersonalTranslation.php
@@ -16,8 +16,11 @@ namespace Sonata\TranslationBundle\Model\Gedmo;
 use Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation as GedmoAbstractPersonalTranslation;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  *
+ * @deprecated since version 2.x, to be removed in 3.0. Create your own instead.
  * @see https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/translatable.md : Personal translations
  */
 class AbstractPersonalTranslation extends GedmoAbstractPersonalTranslation

--- a/src/Model/Gedmo/AbstractTranslatable.php
+++ b/src/Model/Gedmo/AbstractTranslatable.php
@@ -16,12 +16,15 @@ namespace Sonata\TranslationBundle\Model\Gedmo;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * This is your based class if you want to use default gedmo translation with everything in the same table
  * Not recommended if you have a lot of translations
  * (just brings Gedmo locale mapping).
  *
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  *
+ * @deprecated since version 2.x, to be removed in 3.0. Create your own instead.
  * @see https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/translatable.md
  */
 abstract class AbstractTranslatable extends \Sonata\TranslationBundle\Model\AbstractTranslatable

--- a/src/Traits/Gedmo/PersonalTranslatableTrait.php
+++ b/src/Traits/Gedmo/PersonalTranslatableTrait.php
@@ -17,7 +17,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * If you don't want to use trait, you can extend AbstractPersonalTranslatable instead.
+ *
+ * @deprecated since version 2.x, to be removed in 3.0. Create your own trait instead.
  *
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */

--- a/src/Traits/Gedmo/TranslatableTrait.php
+++ b/src/Traits/Gedmo/TranslatableTrait.php
@@ -14,7 +14,11 @@ declare(strict_types=1);
 namespace Sonata\TranslationBundle\Traits\Gedmo;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * If you don't want to use trait, you can extend AbstractTranslatable instead.
+ *
+ * @deprecated since version 2.x, to be removed in 3.0. Create your own trait instead.
  *
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */

--- a/src/Traits/TranslatableTrait.php
+++ b/src/Traits/TranslatableTrait.php
@@ -14,9 +14,13 @@ declare(strict_types=1);
 namespace Sonata\TranslationBundle\Traits;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * If you don't want to use trait, you can extend AbstractTranslatable instead.
  *
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
+ *
+ * @deprecated since version 2.x and will be removed in 3.0.
  */
 trait TranslatableTrait
 {

--- a/tests/Checker/TranslatableCheckerTest.php
+++ b/tests/Checker/TranslatableCheckerTest.php
@@ -13,18 +13,22 @@ declare(strict_types=1);
 
 namespace Sonata\TranslationBundle\Tests\Checker;
 
+use Gedmo\Translatable\Translatable;
 use PHPUnit\Framework\TestCase;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\Model\TranslatableInterface;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelCustomTranslatable;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelTranslatable;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelUsingTraitTranslatable;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */
 final class TranslatableCheckerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testIsTranslatableOnInterface(): void
     {
         $translatableChecker = new TranslatableChecker();
@@ -55,11 +59,19 @@ final class TranslatableCheckerTest extends TestCase
         static::assertTrue($translatableChecker->isTranslatable($object));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testIsTranslatableOnTrait(): void
     {
         $translatableChecker = new TranslatableChecker();
+        $translatableChecker->setSupportedInterfaces([Translatable::class]);
 
         $object = new ModelUsingTraitTranslatable();
+
+        $this->expectDeprecation('Using traits to specify that a model is translatable is deprecated since sonata-project/translation-bundle 2.x and will be not possible in version 3.0. To mark "Sonata\TranslationBundle\Tests\Fixtures\Model\ModelUsingTraitTranslatable" class as translatable you should implement one of "Gedmo\Translatable\Translatable" interfaces.');
 
         static::assertTrue($translatableChecker->isTranslatable($object));
     }

--- a/tests/Fixtures/Model/ModelUsingTraitTranslatable.php
+++ b/tests/Fixtures/Model/ModelUsingTraitTranslatable.php
@@ -15,6 +15,9 @@ namespace Sonata\TranslationBundle\Tests\Fixtures\Model;
 
 use Sonata\TranslationBundle\Traits\TranslatableTrait;
 
+/**
+ * NEXT_MAJOR: Remove this class.
+ */
 class ModelUsingTraitTranslatable
 {
     use TranslatableTrait;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

This bundle is supposed to handle the translation of models used in admins, but we should not provide abstract models nor traits. 

The user should not extend their models from this bundle, but instead create their own (we could also deprecate our interfaces to use the ones from the libraries).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslatable` class
- `Sonata\TranslationBundle\Model\Gedmo\AbstractPersonalTranslation` class
- `Sonata\TranslationBundle\Model\Gedmo\AbstractTranslatable` class
- `Sonata\TranslationBundle\Model\AbstractTranslatable` class
- `Sonata\TranslationBundle\Traits\Gedmo\PersonalTranslatableTrait` trait
- `Sonata\TranslationBundle\Traits\Gedmo\TranslatableTrait` trait
- `Sonata\TranslationBundle\Traits\TranslatableTrait` trait
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
