### PR TITLE
Add current_locale variable in LocaleSwitcherBlockService

### DIFF
--- a/src/Block/LocaleSwitcherBlockService.php
+++ b/src/Block/LocaleSwitcherBlockService.php
@@ -30,10 +30,7 @@ final class LocaleSwitcherBlockService extends AbstractBlockService
      */
     private $localeProvider;
 
-    /**
-     * NEXT_MAJOR: Make the $localeProvider mandatory
-     */
-    public function __construct(Environment $twig, ?LocaleProviderInterface $localeProvider = null)
+    public function __construct(Environment $twig, LocaleProviderInterface $localeProvider)
     {
         parent::__construct($twig);
         $this->localeProvider = $localeProvider;
@@ -48,7 +45,7 @@ final class LocaleSwitcherBlockService extends AbstractBlockService
                 'template' => '@SonataTranslation/Block/block_locale_switcher.html.twig',
                 'locale_switcher_route' => null,
                 'locale_switcher_route_parameters' => [],
-                'current_locale' => $this->localeProvider ? $this->localeProvider->get() : null,
+                'current_locale' => $this->localeProvider->get(),
             ]
         );
     }

--- a/src/Block/LocaleSwitcherBlockService.php
+++ b/src/Block/LocaleSwitcherBlockService.php
@@ -15,14 +15,27 @@ namespace Sonata\TranslationBundle\Block;
 
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\TranslationBundle\Provider\LocaleProviderInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */
 final class LocaleSwitcherBlockService extends AbstractBlockService
 {
+    /**
+     * @var LocaleProviderInterface
+     */
+    private $localeProvider;
+
+    public function __construct(Environment $twig, LocaleProviderInterface $localeProvider)
+    {
+        parent::__construct($twig);
+        $this->localeProvider = $localeProvider;
+    }
+
     public function configureSettings(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
@@ -32,6 +45,7 @@ final class LocaleSwitcherBlockService extends AbstractBlockService
                 'template' => '@SonataTranslation/Block/block_locale_switcher.html.twig',
                 'locale_switcher_route' => null,
                 'locale_switcher_route_parameters' => [],
+                'current_locale' => $this->localeProvider->get(),
             ]
         );
     }

--- a/src/Block/LocaleSwitcherBlockService.php
+++ b/src/Block/LocaleSwitcherBlockService.php
@@ -30,7 +30,10 @@ final class LocaleSwitcherBlockService extends AbstractBlockService
      */
     private $localeProvider;
 
-    public function __construct(Environment $twig, LocaleProviderInterface $localeProvider)
+    /**
+     * NEXT_MAJOR: Make the $localeProvider mandatory
+     */
+    public function __construct(Environment $twig, ?LocaleProviderInterface $localeProvider = null)
     {
         parent::__construct($twig);
         $this->localeProvider = $localeProvider;
@@ -45,7 +48,7 @@ final class LocaleSwitcherBlockService extends AbstractBlockService
                 'template' => '@SonataTranslation/Block/block_locale_switcher.html.twig',
                 'locale_switcher_route' => null,
                 'locale_switcher_route_parameters' => [],
-                'current_locale' => $this->localeProvider->get(),
+                'current_locale' => $this->localeProvider ? $this->localeProvider->get() : null,
             ]
         );
     }

--- a/src/Resources/config/block.php
+++ b/src/Resources/config/block.php
@@ -21,5 +21,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata_translation.block.locale_switcher', LocaleSwitcherBlockService::class)
             ->tag('sonata.block')
-            ->args([new ReferenceConfigurator('twig')]);
+            ->args([
+                new ReferenceConfigurator('twig'),
+                new ReferenceConfigurator('sonata_translation.admin.provider.request_locale_provider'),
+            ]);
 };

--- a/src/Resources/views/Block/block_locale_switcher.html.twig
+++ b/src/Resources/views/Block/block_locale_switcher.html.twig
@@ -2,16 +2,9 @@
 
 {% if admin.class is translatable %}
     {% set object = block_context.settings.object %}
-    {% set currentLocale = object.locale|default(null) %}
     {% set object_id = object ? admin.id(object) : null %}
     {% set locale_switcher_route = block_context.settings.locale_switcher_route|default(object_id is not null ? 'edit' : 'create') %}
     {% set locale_switcher_route_parameters = block_context.settings.locale_switcher_route_parameters %}
-
-    {% for extension in admin.extensions %}
-        {% if extension.translatableLocale is defined %}
-            {% set currentLocale = extension.translatableLocale(admin) %}
-        {% endif %}
-    {% endfor %}
 
     <div class="locale_switcher">
         {% apply spaceless %}
@@ -21,7 +14,7 @@
                     {'id': object_id, 'tl': locale}|merge(locale_switcher_route_parameters)
                 ) }}"
                    accesskey=""
-                   {% if currentLocale == locale %}class="active"{% endif %}
+                   {% if block_context.settings.current_locale == locale %}class="active"{% endif %}
                    title="{{ 'admin.locale_switcher.tooltip' |trans([], 'SonataTranslationBundle') }}">
                     {{ locale|localeName(app.request.locale) }}
                 </a>

--- a/tests/Block/LocaleSwitcherBlockServiceTest.php
+++ b/tests/Block/LocaleSwitcherBlockServiceTest.php
@@ -15,6 +15,7 @@ namespace Sonata\TranslationBundle\Tests\Block;
 
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\TranslationBundle\Block\LocaleSwitcherBlockService;
+use Sonata\TranslationBundle\Provider\LocaleProviderInterface;
 use Twig\Environment;
 
 final class LocaleSwitcherBlockServiceTest extends BlockServiceTestCase
@@ -22,8 +23,10 @@ final class LocaleSwitcherBlockServiceTest extends BlockServiceTestCase
     public function testDefaultSettings(): void
     {
         $environment = $this->createStub(Environment::class);
+        $localeProvider = $this->createStub(LocaleProviderInterface::class);
+        $localeProvider->method('get')->willReturn('en');
 
-        $localeSwitcherBlock = new LocaleSwitcherBlockService($environment);
+        $localeSwitcherBlock = new LocaleSwitcherBlockService($environment, $localeProvider);
 
         $blockContext = $this->getBlockContext($localeSwitcherBlock);
 
@@ -33,6 +36,7 @@ final class LocaleSwitcherBlockServiceTest extends BlockServiceTestCase
             'template' => '@SonataTranslation/Block/block_locale_switcher.html.twig',
             'locale_switcher_route' => null,
             'locale_switcher_route_parameters' => [],
+            'current_locale' => 'en',
         ], $blockContext);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Change visibility of a translatable locale, because its used in the template
https://github.com/sonata-project/SonataTranslationBundle/blob/737b8d5218fbb0becb7af2bfea97cad4fe92c07a/src/Resources/views/Block/block_locale_switcher.html.twig#L11

I am targeting this branch, because BC-break.

## Changelog

```markdown
### Fixed
- Fixed accessing current locale from `block_locale_switcher.html.twig` template
```

