### PR TITLE
Set locale to gedmo listener

### DIFF
--- a/phpstan-object-manager.php
+++ b/phpstan-object-manager.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Sonata\TranslationBundle\Tests\App\AppKernel;
+
+require __DIR__.'/vendor/autoload.php';
+
+$kernel = new AppKernel();
+$kernel->boot();
+
+return $kernel->getContainer()->get('doctrine')->getManager();

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,9 @@ parameters:
     bootstrapFiles:
         - vendor/bin/.phpunit/phpunit/vendor/autoload.php
 
+    doctrine:
+        objectManagerLoader: phpstan-object-manager.php
+
     paths:
         - src
         - tests

--- a/src/DependencyInjection/SonataTranslationExtension.php
+++ b/src/DependencyInjection/SonataTranslationExtension.php
@@ -191,6 +191,7 @@ class SonataTranslationExtension extends Extension
         $container->register('sonata_translation.listener.translatable', TranslatableListener::class)
             ->addMethodCall('setAnnotationReader', [new Reference('annotation_reader')])
             ->addMethodCall('setDefaultLocale', ['%locale%'])
+            ->addMethodCall('setTranslatableLocale', ['%locale%'])
             ->addMethodCall('setTranslationFallback', [false])
             ->addTag('doctrine.event_subscriber');
     }

--- a/tests/App/DataFixtures/GedmoCategoryFixtures.php
+++ b/tests/App/DataFixtures/GedmoCategoryFixtures.php
@@ -15,7 +15,6 @@ namespace Sonata\TranslationBundle\Tests\App\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
-use Gedmo\Translatable\Entity\Repository\TranslationRepository;
 use Gedmo\Translatable\Entity\Translation;
 use Sonata\TranslationBundle\Tests\App\Entity\GedmoCategory;
 
@@ -23,15 +22,11 @@ final class GedmoCategoryFixtures extends Fixture
 {
     public const CATEGORY = 'category_novel';
 
-    /**
-     * @psalm-suppress RedundantCondition psalm does not need the assertion of the repository class
-     */
     public function load(ObjectManager $manager): void
     {
         $novelCategory = new GedmoCategory(self::CATEGORY, 'Novel');
 
         $repository = $manager->getRepository(Translation::class);
-        \assert($repository instanceof TranslationRepository);
         $repository
             ->translate($novelCategory, 'name', 'es', 'Novela')
             ->translate($novelCategory, 'name', 'fr', 'Roman');

--- a/tests/App/DataFixtures/GedmoCategoryFixtures.php
+++ b/tests/App/DataFixtures/GedmoCategoryFixtures.php
@@ -15,27 +15,28 @@ namespace Sonata\TranslationBundle\Tests\App\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
+use Gedmo\Translatable\Entity\Repository\TranslationRepository;
+use Gedmo\Translatable\Entity\Translation;
 use Sonata\TranslationBundle\Tests\App\Entity\GedmoCategory;
 
 final class GedmoCategoryFixtures extends Fixture
 {
     public const CATEGORY = 'category_novel';
 
+    /**
+     * @psalm-suppress RedundantCondition psalm does not need the assertion of the repository class
+     */
     public function load(ObjectManager $manager): void
     {
         $novelCategory = new GedmoCategory(self::CATEGORY, 'Novel');
 
+        $repository = $manager->getRepository(Translation::class);
+        \assert($repository instanceof TranslationRepository);
+        $repository
+            ->translate($novelCategory, 'name', 'es', 'Novela')
+            ->translate($novelCategory, 'name', 'fr', 'Roman');
+
         $manager->persist($novelCategory);
-        $manager->flush();
-
-        $novelCategory->setLocale('es');
-        $novelCategory->setName('Novela');
-
-        $manager->flush();
-
-        $novelCategory->setLocale('fr');
-        $novelCategory->setName('Roman');
-
         $manager->flush();
     }
 }

--- a/tests/App/Entity/KnpCategoryTranslation.php
+++ b/tests/App/Entity/KnpCategoryTranslation.php
@@ -34,7 +34,7 @@ class KnpCategoryTranslation implements TranslationInterface
     /**
      * @var string|null
      *
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type="string", length=255, nullable=true)
      */
     private $name;
 

--- a/tests/DependencyInjection/SonataTranslationExtensionTest.php
+++ b/tests/DependencyInjection/SonataTranslationExtensionTest.php
@@ -121,6 +121,12 @@ final class SonataTranslationExtensionTest extends AbstractExtensionTestCase
             'setAnnotationReader',
             [new Reference('annotation_reader')]
         );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata_translation.listener.translatable',
+            'setTranslatableLocale',
+            ['%locale%']
+        );
     }
 
     protected function getContainerExtensions(): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When using our gedmo translatable listener, if the locale is not set, it uses the its default one which is `en_US`.

This call is also made in the listener defined by [StofDoctrineExtensionsBundle](https://github.com/stof/StofDoctrineExtensionsBundle/blob/7322d49bd7ff408e44704c0cd939889ddbb490f6/src/Resources/config/translatable.xml#L19-L21)

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Setting the proper locale to Gedmo translatable listener
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
