### PR TITLE
Remove TranslatableInterface::getLocale

### DIFF
--- a/src/Admin/Extension/Gedmo/TranslatableAdminExtension.php
+++ b/src/Admin/Extension/Gedmo/TranslatableAdminExtension.php
@@ -56,9 +56,11 @@ final class TranslatableAdminExtension extends AbstractTranslatableAdminExtensio
 
     public function alterNewInstance(AdminInterface $admin, object $object): void
     {
-        if (null === $object->getLocale()) {
-            $object->setLocale($this->getTranslatableLocale());
+        if (!$this->getTranslatableChecker()->isTranslatable($object)) {
+            return;
         }
+
+        $object->setLocale($this->getTranslatableLocale());
     }
 
     public function alterObject(AdminInterface $admin, object $object): void

--- a/src/Model/TranslatableInterface.php
+++ b/src/Model/TranslatableInterface.php
@@ -19,6 +19,4 @@ namespace Sonata\TranslationBundle\Model;
 interface TranslatableInterface
 {
     public function setLocale(string $locale): void;
-
-    public function getLocale(): ?string;
 }

--- a/tests/App/Entity/GedmoCategory.php
+++ b/tests/App/Entity/GedmoCategory.php
@@ -42,7 +42,7 @@ class GedmoCategory implements TranslatableInterface
      *
      * @var string|null
      */
-    private $locale;
+    private $locale = null;
 
     public function __construct(string $id = '', string $name = '')
     {
@@ -75,10 +75,7 @@ class GedmoCategory implements TranslatableInterface
         $this->name = $name;
     }
 
-    /**
-     * @param string $locale
-     */
-    public function setLocale($locale): void
+    public function setLocale(string $locale): void
     {
         $this->locale = $locale;
     }

--- a/tests/Fixtures/Model/ModelTranslatable.php
+++ b/tests/Fixtures/Model/ModelTranslatable.php
@@ -23,7 +23,7 @@ class ModelTranslatable implements TranslatableInterface
      *
      * @var string|null
      */
-    private $locale;
+    private $locale = null;
 
     public function setLocale(string $locale): void
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There is no need to have this method, as we do in `TranslatableAdminExtension::alterObject()` we directly set the locale when creating the object.

Ideally, I think we should remove the interface since `gedmo` do not enforce to use one, we could use the `TranslatableListener` to fetch the configuration for an entity and set the value with reflection as they do.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this breaks BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed `TranslatableInterface::getLocale()` method
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
