### PR TITLE
Deprecate model interfaces

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -28,6 +28,18 @@ It is deprecated implementing `Sonata\TranslationBundle\Model\TranslatableInterf
 `Sonata\TranslationBundle\Admin\Extension\Phpcr\TranslatableAdminExtension` classes must receive an instance of
 `LocaleProviderInterface` as second argument.
 
+### Deprecated `Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface`
+
+When using `gedmo/doctrine-extensions` you MUST implement `Gedmo\Translatable\Translatable` instead.
+
+### Deprecated `Sonata\TranslationBundle\Model\TranslatableInterface`
+
+This interface has been deprecated without replacement, you MUST implement the specific interface based on the
+translation package you are using:
+
+- knplabs: `Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface`
+- gedmo: `Gedmo\Translatable\Translatable`
+
 UPGRADE FROM 2.7 to 2.8
 =======================
 

--- a/src/DependencyInjection/SonataTranslationExtension.php
+++ b/src/DependencyInjection/SonataTranslationExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\TranslationBundle\DependencyInjection;
 
+use Gedmo\Translatable\Translatable as GedmoTranslatable;
 use Gedmo\Translatable\TranslatableListener;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface as KNPTranslatableInterface;
 use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface as GedmoTranslatableInterface;
@@ -74,7 +75,11 @@ class SonataTranslationExtension extends Extension
              * @phpstan-var list<class-string>
              */
             $listOfInterfaces = array_merge(
-                [GedmoTranslatableInterface::class],
+                [
+                    // NEXT_MAJOR: Remove next line.
+                    GedmoTranslatableInterface::class,
+                    GedmoTranslatable::class,
+                ],
                 $config['gedmo']['implements']
             );
             $translationTargets['gedmo']['implements'] = $listOfInterfaces;

--- a/src/Filter/TranslationFieldFilter.php
+++ b/src/Filter/TranslationFieldFilter.php
@@ -34,8 +34,6 @@ final class TranslationFieldFilter extends Filter
     }
 
     /**
-     * $data is an array according to phpdoc.
-     *
      * @psalm-suppress RedundantCondition
      */
     public function filter(ProxyQueryInterface $query, $alias, $field, $data): void

--- a/src/Model/Gedmo/TranslatableInterface.php
+++ b/src/Model/Gedmo/TranslatableInterface.php
@@ -18,6 +18,8 @@ use Sonata\TranslationBundle\Model\TranslatableInterface as GenericTranslatableI
 /**
  * This is a Convenient interface made to easily plug Gedmo admin extension on models.
  *
+ * @deprecated since sonata-project/translation-bundle 2.x, to be removed in 3.0.
+ *
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */
 interface TranslatableInterface extends GenericTranslatableInterface

--- a/src/Model/TranslatableInterface.php
+++ b/src/Model/TranslatableInterface.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sonata\TranslationBundle\Model;
 
 /**
+ * @deprecated since sonata-project/translation-bundle 2.x, to be removed in 3.0.
+ *
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
  */
 interface TranslatableInterface

--- a/tests/Admin/Extension/Gedmo/DeprecatedTranslatableAdminExtensionTest.php
+++ b/tests/Admin/Extension/Gedmo/DeprecatedTranslatableAdminExtensionTest.php
@@ -23,7 +23,7 @@ use Sonata\TranslationBundle\Admin\Extension\AbstractTranslatableAdminExtension;
 use Sonata\TranslationBundle\Admin\Extension\Gedmo\TranslatableAdminExtension;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\Model\TranslatableInterface;
-use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelTranslatable;
+use Sonata\TranslationBundle\Tests\Fixtures\Model\DeprecatedModelTranslatable;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\Container;
@@ -44,7 +44,7 @@ final class DeprecatedTranslatableAdminExtensionTest extends WebTestCase
     private $admin;
 
     /**
-     * @var ModelTranslatable
+     * @var DeprecatedModelTranslatable
      */
     private $object;
 
@@ -100,7 +100,7 @@ final class DeprecatedTranslatableAdminExtensionTest extends WebTestCase
             ->method('getConfigurationPool')
             ->willReturn($pool);
 
-        $this->object = new ModelTranslatable();
+        $this->object = new DeprecatedModelTranslatable();
     }
 
     public function testSetLocaleForTranslatableObject(): void

--- a/tests/Admin/Extension/Gedmo/TranslatableAdminExtensionTest.php
+++ b/tests/Admin/Extension/Gedmo/TranslatableAdminExtensionTest.php
@@ -13,8 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\TranslationBundle\Tests\Admin\Extension\Gedmo;
 
+use Doctrine\Common\EventManager;
 use Doctrine\Persistence\ManagerRegistry;
-use Doctrine\Persistence\ObjectManager;
+use Gedmo\Translatable\Translatable;
 use Gedmo\Translatable\TranslatableListener;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
@@ -24,20 +25,15 @@ use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\Model\TranslatableInterface;
 use Sonata\TranslationBundle\Provider\LocaleProviderInterface;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelTranslatable;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Sonata\TranslationBundle\Tests\Traits\DoctrineOrmTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
-final class TranslatableAdminExtensionTest extends WebTestCase
+final class TranslatableAdminExtensionTest extends DoctrineOrmTestCase
 {
     /**
      * @var AdminInterface<TranslatableInterface>
      */
     private $admin;
-
-    /**
-     * @var ModelTranslatable
-     */
-    private $object;
 
     /**
      * @var TranslatableAdminExtension
@@ -53,15 +49,21 @@ final class TranslatableAdminExtensionTest extends WebTestCase
     {
         $translatableChecker = new TranslatableChecker();
         $translatableChecker->setSupportedInterfaces([
+            // NEXT_MAJOR: Remove next line
             TranslatableInterface::class,
+            Translatable::class,
         ]);
 
+        $evm = new EventManager();
         $this->translatableListener = new TranslatableListener();
-        $objectManager = $this->createStub(ObjectManager::class);
+        $this->translatableListener->setTranslatableLocale('en');
+        $this->translatableListener->setDefaultLocale('en');
+        $evm->addEventSubscriber($this->translatableListener);
+        $this->getMockSqliteEntityManager($evm);
         $managerRegistry = $this->createStub(ManagerRegistry::class);
         $managerRegistry
             ->method('getManagerForClass')
-            ->willReturn($objectManager);
+            ->willReturn($this->em);
 
         $localeProvider = new class() implements LocaleProviderInterface {
             public function get(): string
@@ -83,22 +85,35 @@ final class TranslatableAdminExtensionTest extends WebTestCase
         $this->admin = $this->createMock(AdminInterface::class);
         $this->admin->method('getRequest')->willReturn($request);
         $this->admin->method('hasRequest')->willReturn(true);
-
-        $this->object = new ModelTranslatable();
     }
 
+    /**
+     * @psalm-suppress InvalidArgument Each extension will handle specific type on NEXT_MAJOR
+     */
     public function testSetLocaleForTranslatableObject(): void
     {
-        $this->extension->alterNewInstance($this->admin, $this->object);
+        $object = new ModelTranslatable();
+        $this->em->persist($object);
 
-        static::assertSame('es', $this->object->getLocale());
+        // @phpstan-ignore-next-line Each extension will handle specific type
+        $this->extension->alterNewInstance($this->admin, $object);
+
+        static::assertSame('es', $object->locale);
     }
 
+    /**
+     * @psalm-suppress InvalidArgument Each extension will handle specific type on NEXT_MAJOR
+     */
     public function testAlterObjectForTranslatableObject(): void
     {
-        $this->extension->alterObject($this->admin, $this->object);
+        $object = new ModelTranslatable();
+        $this->em->persist($object);
+        $this->em->flush();
 
-        static::assertSame('es', $this->object->getLocale());
+        // @phpstan-ignore-next-line Each extension will handle specific type
+        $this->extension->alterObject($this->admin, $object);
+
+        static::assertSame('es', $object->locale);
     }
 
     public function testConfigureQuery(): void
@@ -109,5 +124,10 @@ final class TranslatableAdminExtensionTest extends WebTestCase
 
         static::assertSame('es', $this->translatableListener->getListenerLocale());
         static::assertFalse($this->translatableListener->getTranslationFallback());
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [ModelTranslatable::class];
     }
 }

--- a/tests/App/Entity/GedmoCategory.php
+++ b/tests/App/Entity/GedmoCategory.php
@@ -15,10 +15,10 @@ namespace Sonata\TranslationBundle\Tests\App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
-use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
+use Gedmo\Translatable\Translatable;
 
 /** @ORM\Entity */
-class GedmoCategory implements TranslatableInterface
+class GedmoCategory implements Translatable
 {
     /**
      * @ORM\Id

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Gedmo\Translatable\Translatable as GedmoTranslatable;
 use Gedmo\Translatable\TranslatableListener;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface as KnpTranslatableInterface;
 use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface as GedmoTranslatableInterfaceAlias;
@@ -26,7 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->parameters()
         ->set('sonata_translation.targets', [
             'gedmo' => [
-                'implements' => [GedmoTranslatableInterfaceAlias::class],
+                'implements' => [GedmoTranslatable::class, GedmoTranslatableInterfaceAlias::class],
                 'instanceof' => [],
             ],
             'knplabs' => [

--- a/tests/Checker/TranslatableCheckerTest.php
+++ b/tests/Checker/TranslatableCheckerTest.php
@@ -17,8 +17,8 @@ use Gedmo\Translatable\Translatable;
 use PHPUnit\Framework\TestCase;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\Model\TranslatableInterface;
+use Sonata\TranslationBundle\Tests\Fixtures\Model\DeprecatedModelTranslatable;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelCustomTranslatable;
-use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelTranslatable;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelUsingTraitTranslatable;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
@@ -29,11 +29,14 @@ final class TranslatableCheckerTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     */
     public function testIsTranslatableOnInterface(): void
     {
         $translatableChecker = new TranslatableChecker();
 
-        $object = new ModelTranslatable();
+        $object = new DeprecatedModelTranslatable();
 
         static::assertFalse($translatableChecker->isTranslatable($object));
 

--- a/tests/Fixtures/Model/DeprecatedModelTranslatable.php
+++ b/tests/Fixtures/Model/DeprecatedModelTranslatable.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TranslationBundle\Tests\Fixtures\Model;
+
+use Sonata\TranslationBundle\Model\Gedmo\AbstractTranslatable;
+use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
+
+class DeprecatedModelTranslatable extends AbstractTranslatable implements TranslatableInterface
+{
+}

--- a/tests/Fixtures/Model/ModelTranslatable.php
+++ b/tests/Fixtures/Model/ModelTranslatable.php
@@ -13,9 +13,26 @@ declare(strict_types=1);
 
 namespace Sonata\TranslationBundle\Tests\Fixtures\Model;
 
-use Sonata\TranslationBundle\Model\Gedmo\AbstractTranslatable;
-use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Gedmo\Translatable\Translatable;
 
-class ModelTranslatable extends AbstractTranslatable implements TranslatableInterface
+/** @ORM\Entity() */
+class ModelTranslatable implements Translatable
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null
+     */
+    public $id;
+
+    /**
+     * @Gedmo\Locale()
+     *
+     * @var string|null
+     */
+    public $locale = null;
 }

--- a/tests/Model/GedmoTest.php
+++ b/tests/Model/GedmoTest.php
@@ -15,9 +15,9 @@ namespace Sonata\TranslationBundle\Tests\Model;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface;
+use Sonata\TranslationBundle\Tests\Fixtures\Model\DeprecatedModelTranslatable;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelPersonalTranslatable;
 use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelPersonalTranslation;
-use Sonata\TranslationBundle\Tests\Fixtures\Model\ModelTranslatable;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
@@ -26,7 +26,7 @@ final class GedmoTest extends TestCase
 {
     public function testTranslatableModel(): void
     {
-        $model = new ModelTranslatable();
+        $model = new DeprecatedModelTranslatable();
         $model->setLocale('fr');
 
         static::assertSame('fr', $model->getLocale());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Users should not implement model interfaces from this bundle, instead they should rely on the ones provided by the translation packages.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `Sonata\TranslationBundle\Model\TranslatableInterface` in favor of specific package interfaces (gedmo or knplabs)
- `Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface` in favor of `Gedmo\Translatable\Translatable`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
