### PR TITLE
Only call refresh when the locale is different in the entity

### DIFF
--- a/src/Admin/Extension/Gedmo/TranslatableAdminExtension.php
+++ b/src/Admin/Extension/Gedmo/TranslatableAdminExtension.php
@@ -136,7 +136,6 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
             return;
         }
 
-        $objectManager->refresh($object);
         $this->setLocale($object, $admin);
     }
 
@@ -214,6 +213,15 @@ class TranslatableAdminExtension extends AbstractTranslatableAdminExtension
 
         $reflectionProperty = $reflClass->getProperty($configuration['locale']);
         $reflectionProperty->setAccessible(true);
+
+        if ($reflectionProperty->getValue($object) === $translatableLocale) {
+            return;
+        }
+
         $reflectionProperty->setValue($object, $translatableLocale);
+
+        if ($objectManager->contains($object)) {
+            $objectManager->refresh($object);
+        }
     }
 }

--- a/tests/Admin/Extension/Gedmo/TranslatableAdminExtensionTest.php
+++ b/tests/Admin/Extension/Gedmo/TranslatableAdminExtensionTest.php
@@ -93,7 +93,6 @@ final class TranslatableAdminExtensionTest extends DoctrineOrmTestCase
     public function testSetLocaleForTranslatableObject(): void
     {
         $object = new ModelTranslatable();
-        $this->em->persist($object);
 
         // @phpstan-ignore-next-line Each extension will handle specific type
         $this->extension->alterNewInstance($this->admin, $object);
@@ -124,6 +123,48 @@ final class TranslatableAdminExtensionTest extends DoctrineOrmTestCase
 
         static::assertSame('es', $this->translatableListener->getListenerLocale());
         static::assertFalse($this->translatableListener->getTranslationFallback());
+    }
+
+    public function testRefreshIsCalledWithDifferentLocale(): void
+    {
+        $object = new ModelTranslatable();
+        $object->locale = 'en';
+        $this->em->persist($object);
+        $this->em->flush();
+
+        $object->refreshableField = 'new value';
+
+        /**
+         * NEXT_MAJOR: Remove this comment, each extension will handle specific type.
+         *
+         * @psalm-suppress InvalidArgument
+         * @phpstan-ignore-next-line
+         */
+        $this->extension->alterObject($this->admin, $object);
+
+        /** @psalm-suppress TypeDoesNotContainType */
+        static::assertSame('', $object->refreshableField);
+    }
+
+    public function testRefreshIsNotCalledWithTheSameLocale(): void
+    {
+        $object = new ModelTranslatable();
+        $object->locale = 'es';
+        $this->em->persist($object);
+        $this->em->flush();
+
+        $object->refreshableField = 'new value';
+
+        /**
+         * NEXT_MAJOR: Remove this comment, each extension will handle specific type.
+         *
+         * @psalm-suppress InvalidArgument
+         * @phpstan-ignore-next-line
+         */
+        $this->extension->alterObject($this->admin, $object);
+
+        /** @psalm-suppress RedundantCondition */
+        static::assertSame('new value', $object->refreshableField);
     }
 
     protected function getUsedEntityFixtures(): array

--- a/tests/Fixtures/Model/ModelTranslatable.php
+++ b/tests/Fixtures/Model/ModelTranslatable.php
@@ -35,4 +35,11 @@ class ModelTranslatable implements Translatable
      * @var string|null
      */
     public $locale = null;
+
+    /**
+     * @ORM\Column(type="string", length=10)
+     *
+     * @var string
+     */
+    public $refreshableField = '';
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Try to fix https://github.com/sonata-project/SonataTranslationBundle/issues/506

I've never had this problem because I'm not using the bundle with an admin with sub items, this is just a try to see if it works.

@benjamin-hubert if you could please try it.

@wokenlex I don't know if your problem is related also with this.

It's only changed when using non-deprecated interfaces (only implementing `Translatable` from Gedmo and not `TranslatableInterface` from this bundle).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #506

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Creating or updating an entity with translatable sub items
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

If this is fine, I would try to create a test with panther