### PR TITLE
Deprecate locale_switcher option

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,6 +1,15 @@
 UPGRADE 2.x
 ===========
 
+### Deprecated `locale_switcher` option
+
+This option registers two event subscribers that have been also deprecated:
+
+- `Sonata\TranslationBundle\EventSubscriber\LocaleSubscriber`: Without replacement since Symfony executes
+the same logic.
+- `Sonata\TranslationBundle\EventSubscriber\UserLocaleSubscriber`: If you need to set the locale based on the user
+preference, you MUST implement your own listener, for this you can follow Symfony docs: https://symfony.com/index.php/doc/current/session/locale_sticky_session.html#setting-the-locale-based-on-the-user-s-preferences
+
 UPGRADE FROM 2.9 to 2.10
 ========================
 

--- a/docs/reference/global_locale_switcher.rst
+++ b/docs/reference/global_locale_switcher.rst
@@ -33,15 +33,6 @@ Configure route:
     sonata_translation:
         resource: '@SonataTranslationBundle/Resources/config/routes.yaml'
 
-Enable ``locale_switcher``:
-
-.. code-block:: yaml
-
-    # config/packages/sonata_translation.yaml
-
-    sonata_translation:
-        locale_switcher: true
-
 How it looks
 ------------
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -105,7 +105,13 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                // NEXT_MAJOR: Remove this option.
                 ->booleanNode('locale_switcher')
+                    ->setDeprecated(
+                        'The "%node%" option is deprecated since sonata-project/translation-bundle 3.x. If you want to'
+                        .'set the locale based on the user preference, create your own event listener following'
+                        .'https://symfony.com/index.php/doc/current/session/locale_sticky_session.html#setting-the-locale-based-on-the-user-s-preferences'
+                    )
                     ->info('Enable the global locale switcher services.')
                     ->defaultFalse()
                 ->end()

--- a/src/DependencyInjection/SonataTranslationExtension.php
+++ b/src/DependencyInjection/SonataTranslationExtension.php
@@ -52,6 +52,7 @@ class SonataTranslationExtension extends Extension
         $loader->load('provider.xml');
         $loader->load('twig_intl.xml');
 
+        // NEXT_MAJOR: Remove the "if" block.
         if ($config['locale_switcher']) {
             $loader->load('service_locale_switcher.xml');
         }

--- a/src/EventSubscriber/LocaleSubscriber.php
+++ b/src/EventSubscriber/LocaleSubscriber.php
@@ -18,7 +18,11 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * @author Jonathan Vautrin <jvautrin@pro-info.be>
+ *
+ * @deprecated since sonata-project/translation-bundle 2.x, to be removed in 3.0.
  */
 final class LocaleSubscriber implements EventSubscriberInterface
 {

--- a/src/EventSubscriber/UserLocaleSubscriber.php
+++ b/src/EventSubscriber/UserLocaleSubscriber.php
@@ -19,10 +19,14 @@ use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * Stores the locale of the user in the session after the
  * login. This can be used by the LocaleSubscriber afterwards.
  *
  * @author Jonathan Vautrin <jvautrin@pro-info.be>
+ *
+ * @deprecated since sonata-project/translation-bundle 2.x, to be removed in 3.0.
  */
 final class UserLocaleSubscriber implements EventSubscriberInterface
 {

--- a/src/Resources/config/service_locale_switcher.xml
+++ b/src/Resources/config/service_locale_switcher.xml
@@ -5,11 +5,14 @@
         <parameter key="sonata_translation.locale_switcher.user_locale_subscriber.class">Sonata\TranslationBundle\EventSubscriber\UserLocaleSubscriber</parameter>
     </parameters>
     <services>
+        <!-- NEXT_MAJOR: Remove this file -->
         <service id="sonata_translation.locale_switcher.locale_subscriber" class="%sonata_translation.locale_switcher.locale_subscriber.class%">
             <argument key="$defaultLocale">%kernel.default_locale%</argument>
+            <deprecated>The "%service_id%" service is deprecated since sonata-project/translation-bundle 2.x and will be removed in 3.0.</deprecated>
             <tag name="kernel.event_subscriber"/>
         </service>
         <service id="sonata_translation.locale_switcher.user_locale_subscriber" class="%sonata_translation.locale_switcher.user_locale_subscriber.class%">
+            <deprecated>The "%service_id%" service is deprecated since sonata-project/translation-bundle 2.x and will be removed in 3.0.</deprecated>
             <tag name="kernel.event_subscriber"/>
         </service>
     </services>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

`locale_switcher` option it is used to load two services, `UserLocaleSubscriber` and `LocaleSubscriber`.

`UserLocaleSubscriber` IMO is too specific, it has nothing to do with this bundle (translations) and the user can follow https://symfony.com/index.php/doc/4.4/session/locale_sticky_session.html#setting-the-locale-based-on-the-user-s-preferences to create its own.

`LocaleSubscriber` it's not really needed because:

https://github.com/sonata-project/SonataTranslationBundle/blob/f4a8392070fc8bfcfa3b007ae7e8739c48280637/src/EventSubscriber/LocaleSubscriber.php#L39-L45

This part is already covered by Symfony: https://symfony.com/doc/4.4/translation/locale.html#the-locale-and-the-url

And the other one:

https://github.com/sonata-project/SonataTranslationBundle/blob/f4a8392070fc8bfcfa3b007ae7e8739c48280637/src/EventSubscriber/LocaleSubscriber.php#L47-L48

It's also covered:

https://github.com/symfony/symfony/blob/677ca9cd03c81c1bcba5bd3e830534be73a5ce53/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php#L43-L46

the default locale we're using is the one from the kernel:

https://github.com/sonata-project/SonataTranslationBundle/blob/f4a8392070fc8bfcfa3b007ae7e8739c48280637/src/Resources/config/service_locale_switcher.php#L23-L27

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `locale_switcher` configuration option which is not needed anymore
- `LocaleSubscriber` class which it functionality is covered by Symfony
- `UserLocaleSubscriber` class in favor of implementing its own solution
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
