### PR TITLE
Use the tag attribute for getting the modelClass and use the argument…

### DIFF
--- a/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
@@ -32,7 +32,11 @@ final class AdminExtensionCompilerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $attributes) {
             $admin = $container->getDefinition($id);
-            $modelClass = $container->getParameterBag()->resolveValue($admin->getArgument(1));
+
+            // NEXT_MAJOR: Remove the $admin->getArguments()[1] fallback.
+            $modelClassName = $attributes[0]['model_class'] ?? $admin->getArguments()[1] ?? null;
+
+            $modelClass = $container->getParameterBag()->resolveValue($modelClassName);
             if (!$modelClass || !class_exists($modelClass)) {
                 continue;
             }

--- a/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminExtensionCompilerPass.php
@@ -30,27 +30,32 @@ final class AdminExtensionCompilerPass implements CompilerPassInterface
         \assert(\is_array($translationTargets));
         $adminExtensionReferences = $this->getAdminExtensionReferenceByTypes(array_keys($translationTargets));
 
-        foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $tags) {
             $admin = $container->getDefinition($id);
 
-            // NEXT_MAJOR: Remove the $admin->getArguments()[1] fallback.
-            $modelClassName = $attributes[0]['model_class'] ?? $admin->getArguments()[1] ?? null;
+            // NEXT_MAJOR: Remove this line.
+            $defaultModelClass = $admin->getArguments()[1] ?? null;
+            foreach ($tags as $attributes) {
+                // NEXT_MAJOR: Remove the fallback to $defaultModelClass and use null instead.
+                $modelClassName = $attributes['model_class'] ?? $defaultModelClass;
 
-            $modelClass = $container->getParameterBag()->resolveValue($modelClassName);
-            if (!$modelClass || !class_exists($modelClass)) {
-                continue;
-            }
-            $modelClassReflection = new \ReflectionClass($modelClass);
+                $modelClass = $container->getParameterBag()->resolveValue($modelClassName);
 
-            foreach ($adminExtensionReferences as $type => $reference) {
-                foreach ($translationTargets[$type]['implements'] as $interface) {
-                    if ($modelClassReflection->implementsInterface($interface)) {
-                        $admin->addMethodCall('addExtension', [$reference]);
-                    }
+                if (!$modelClass || !class_exists($modelClass)) {
+                    continue;
                 }
-                foreach ($translationTargets[$type]['instanceof'] as $class) {
-                    if ($modelClassReflection->getName() === $class || $modelClassReflection->isSubclassOf($class)) {
-                        $admin->addMethodCall('addExtension', [$reference]);
+                $modelClassReflection = new \ReflectionClass($modelClass);
+
+                foreach ($adminExtensionReferences as $type => $reference) {
+                    foreach ($translationTargets[$type]['implements'] as $interface) {
+                        if ($modelClassReflection->implementsInterface($interface)) {
+                            $admin->addMethodCall('addExtension', [$reference]);
+                        }
+                    }
+                    foreach ($translationTargets[$type]['instanceof'] as $class) {
+                        if ($modelClassReflection->getName() === $class || $modelClassReflection->isSubclassOf($class)) {
+                            $admin->addMethodCall('addExtension', [$reference]);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
… only as fallback.

Because passing the code, the model class and the controller name as arguments has been deprecated in SonataAdmin 4.8.0.
Fixes #628

## Subject

I am targeting this branch, because it fixes deprecation notices.

Closes #628.

## Changelog

```markdown
### Fixed
- Support of new admin declaration with `model_class` as attribute
```