### PR TITLE
Translatable Checker user is_a since

### DIFF
--- a/src/Checker/TranslatableChecker.php
+++ b/src/Checker/TranslatableChecker.php
@@ -75,6 +75,8 @@ final class TranslatableChecker
      * Check if $object is translatable.
      *
      * @param object|string|null $object
+     *
+     * @phpstan-param object|class-string|null $object
      */
     public function isTranslatable($object): bool
     {
@@ -82,20 +84,22 @@ final class TranslatableChecker
             return false;
         }
 
-        $objectInterfaces = class_implements($object);
-        \assert(\is_array($objectInterfaces));
-        foreach ($this->getSupportedInterfaces() as $interface) {
-            if (\in_array($interface, $objectInterfaces, true)) {
-                return true;
-            }
-        }
-
-        foreach ($this->getSupportedModels() as $model) {
-            if ($object instanceof $model) {
+        foreach ($this->getSupportedClasses() as $interface) {
+            if (is_a($object, $interface, true)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * @return string[]
+     *
+     * @phpstan-return class-string[]
+     */
+    private function getSupportedClasses(): array
+    {
+        return array_merge($this->getSupportedInterfaces(), $this->getSupportedModels());
     }
 }

--- a/src/Twig/Extension/SonataTranslationExtension.php
+++ b/src/Twig/Extension/SonataTranslationExtension.php
@@ -59,6 +59,8 @@ final class SonataTranslationExtension extends AbstractExtension
      * Check if $object is translatable.
      *
      * @param object|string|null $object
+     *
+     * @phpstan-param object|class-string|null $object
      */
     public function isTranslatable($object): bool
     {


### PR DESCRIPTION
The translatable checker should user is_a instead of instance of since it can receive a string ($object is not necessarily a 'object)

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's a bug, $object is a string in some of the flow.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Sonata\TranslationBundle\Checker\TranslationChecker rely on 'is_a' instead of insteance of to fully support string parameter.

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [x] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.

