### PR TITLE
Fix deprecations with block bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     "homepage": "https://docs.sonata-project.org/projects/SonataTranslationBundle",
     "require": {
         "php": "^7.4 || ^8.0",
-        "sonata-project/admin-bundle": "^4.0",
-        "sonata-project/block-bundle": "^4.0",
+        "sonata-project/admin-bundle": "^4.8",
+        "sonata-project/block-bundle": "^4.11",
         "symfony/config": "^4.4 || ^5.3 || ^6.0",
         "symfony/dependency-injection": "^4.4 || ^5.3 || ^6.0",
         "symfony/form": "^4.4 || ^5.3 || ^6.0",

--- a/src/Block/LocaleSwitcherBlockService.php
+++ b/src/Block/LocaleSwitcherBlockService.php
@@ -53,7 +53,7 @@ final class LocaleSwitcherBlockService extends AbstractBlockService
 
         \assert(\is_string($template));
 
-        return $this->renderPrivateResponse($template, [
+        return $this->renderResponse($template, [
             'block_context' => $blockContext,
             'block' => $blockContext->getBlock(),
         ], $response);

--- a/tests/App/config/config_v4.yml
+++ b/tests/App/config/config_v4.yml
@@ -21,5 +21,6 @@ parameters:
     locale: 'en'
 
 sonata_block:
+    http_cache: false
     blocks:
         sonata_translation.block.locale_switcher: ~

--- a/tests/App/config/config_v5.yml
+++ b/tests/App/config/config_v5.yml
@@ -22,5 +22,6 @@ parameters:
     locale: 'en'
 
 sonata_block:
+    http_cache: false
     blocks:
         sonata_translation.block.locale_switcher: ~

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -30,23 +30,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set(GedmoCategoryAdmin::class)
             ->tag('sonata.admin', [
                 'manager_type' => 'orm',
+                'model_class' => GedmoCategory::class,
                 'label' => 'Gedmo Category',
-            ])
-            ->args([
-                '',
-                GedmoCategory::class,
-                null,
             ])
 
         ->set(KnpCategoryAdmin::class)
             ->tag('sonata.admin', [
                 'manager_type' => 'orm',
+                'model_class' => KnpCategory::class,
                 'label' => 'Knp Category',
-            ])
-            ->args([
-                '',
-                KnpCategory::class,
-                null,
             ])
 
         ->set('app.gedmo.translation_listener', TranslatableListener::class)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fix deprecations with SonataBlockBundle 4.11+ (similar to https://github.com/sonata-project/SonataAdminBundle/pull/7792)

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataTranslationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Locale block response is not rendered as private anymore to be compatible with SonataBlockBundle 5
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
