### PR TITLE
Fixed error 'You have requested a non-existent parameter "locale"'

### DIFF
--- a/src/DependencyInjection/SonataTranslationExtension.php
+++ b/src/DependencyInjection/SonataTranslationExtension.php
@@ -59,7 +59,7 @@ final class SonataTranslationExtension extends Extension
         if ($this->isConfigEnabled($container, $config['gedmo'])) {
             $isEnabled = true;
 
-            $this->registerTranslatableListener($container, $config['gedmo']);
+            $this->registerTranslatableListener($container, $config['gedmo'], $config['default_locale']);
 
             $loader->load('service_gedmo.php');
 
@@ -142,7 +142,7 @@ final class SonataTranslationExtension extends Extension
     /**
      * @param array{enabled: bool, translatable_listener_service?: string, implements: list<class-string>, instanceof: list<class-string>} $gedmoConfig
      */
-    private function registerTranslatableListener(ContainerBuilder $container, array $gedmoConfig): void
+    private function registerTranslatableListener(ContainerBuilder $container, array $gedmoConfig, string $defaultLocale): void
     {
         if (isset($gedmoConfig['translatable_listener_service'])) {
             $container->setAlias(
@@ -153,12 +153,13 @@ final class SonataTranslationExtension extends Extension
             return;
         }
 
+        $locale = $container->hasParameter('locale') ? $container->getParameter('locale') : $defaultLocale;
         // Registration based on the documentation
         // see https://github.com/doctrine-extensions/DoctrineExtensions/blob/7c0d5aeab0f840d2a18a18c3dc10b0117c597a42/doc/symfony4.md#doctrine-extension-listener-services
         $container->register('sonata_translation.listener.translatable', TranslatableListener::class)
             ->addMethodCall('setAnnotationReader', [new Reference('annotation_reader', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)])
-            ->addMethodCall('setDefaultLocale', ['%locale%'])
-            ->addMethodCall('setTranslatableLocale', ['%locale%'])
+            ->addMethodCall('setDefaultLocale', [$locale])
+            ->addMethodCall('setTranslatableLocale', [$locale])
             ->addMethodCall('setTranslationFallback', [false])
             ->addTag('doctrine.event_listener', ['event' => 'postLoad'])
             ->addTag('doctrine.event_listener', ['event' => 'postPersist'])

--- a/tests/DependencyInjection/SonataTranslationExtensionTest.php
+++ b/tests/DependencyInjection/SonataTranslationExtensionTest.php
@@ -76,6 +76,7 @@ final class SonataTranslationExtensionTest extends AbstractExtensionTestCase
             'gedmo' => [
                 'enabled' => true,
             ],
+            'default_locale' => 'testLocale'
         ]);
 
         $this->assertContainerBuilderHasService(
@@ -92,7 +93,36 @@ final class SonataTranslationExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'sonata_translation.listener.translatable',
             'setTranslatableLocale',
-            ['%locale%']
+            ['testLocale']
+        );
+    }
+
+    public function testRegistersTranslatableListenerWhenUsingGedmoAndContainerParameter(): void
+    {
+        $this->container->setParameter('kernel.bundles', []);
+        $this->container->setParameter('locale', 'containerLocale');
+        $this->load([
+            'gedmo' => [
+                'enabled' => true,
+            ],
+            'default_locale' => 'testLocale'
+        ]);
+
+        $this->assertContainerBuilderHasService(
+            'sonata_translation.listener.translatable',
+            TranslatableListener::class
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata_translation.listener.translatable',
+            'setAnnotationReader',
+            [new Reference('annotation_reader', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)]
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata_translation.listener.translatable',
+            'setTranslatableLocale',
+            ['containerLocale']
         );
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixed an issue with the use of the 'locale' parameter no longer being present in new Symfony versions.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTranslationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because I've implemented the fix while maintaining backwards compatibility


## Changelog

```markdown
### Fixed
error 'You have requested a non-existent parameter "locale"' when using Symfony 7
```