### PR TITLE
Feat: Make the bundle work for long running processes

### DIFF
--- a/src/Admin/Extension/AbstractTranslatableAdminExtension.php
+++ b/src/Admin/Extension/AbstractTranslatableAdminExtension.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\Provider\LocaleProviderInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Nicolas Bastien <nbastien.pro@gmail.com>
@@ -26,7 +27,7 @@ use Sonata\TranslationBundle\Provider\LocaleProviderInterface;
  *
  * @internal
  */
-abstract class AbstractTranslatableAdminExtension extends AbstractAdminExtension
+abstract class AbstractTranslatableAdminExtension extends AbstractAdminExtension implements ResetInterface
 {
     /**
      * Request parameter.
@@ -66,5 +67,10 @@ abstract class AbstractTranslatableAdminExtension extends AbstractAdminExtension
         }
 
         return $this->translatableLocale;
+    }
+
+    public function reset(): void
+    {
+        $this->translatableLocale = null;
     }
 }

--- a/src/Provider/RequestLocaleProvider.php
+++ b/src/Provider/RequestLocaleProvider.php
@@ -15,8 +15,9 @@ namespace Sonata\TranslationBundle\Provider;
 
 use Sonata\TranslationBundle\Admin\Extension\AbstractTranslatableAdminExtension;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\ResetInterface;
 
-final class RequestLocaleProvider implements LocaleProviderInterface
+final class RequestLocaleProvider implements LocaleProviderInterface, ResetInterface
 {
     private ?string $translatableLocale = null;
 
@@ -51,5 +52,10 @@ final class RequestLocaleProvider implements LocaleProviderInterface
         }
 
         return $this->defaultTranslationLocale;
+    }
+
+    public function reset(): void
+    {
+        $this->translatableLocale = null;
     }
 }

--- a/src/Resources/config/provider.php
+++ b/src/Resources/config/provider.php
@@ -24,5 +24,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 service('request_stack'),
                 param('sonata_translation.default_locale'),
-            ]);
+            ])
+            ->tag('kernel.reset', ['method' => 'reset']);
 };

--- a/src/Resources/config/service_gedmo.php
+++ b/src/Resources/config/service_gedmo.php
@@ -20,6 +20,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata_translation.admin.extension.gedmo_translatable', TranslatableAdminExtension::class)
             ->tag('sonata.admin.extension')
+            ->tag('kernel.reset', ['method' => 'reset'])
             ->args([
                 service('sonata_translation.checker.translatable'),
                 service('sonata_translation.listener.translatable'),

--- a/src/Resources/config/service_knplabs.php
+++ b/src/Resources/config/service_knplabs.php
@@ -22,6 +22,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata_translation.admin.extension.knplabs_translatable', TranslatableAdminExtension::class)
             ->tag('sonata.admin.extension')
+            ->tag('kernel.reset', ['method' => 'reset'])
             ->args([
                 service('sonata_translation.checker.translatable'),
                 service('sonata_translation.admin.provider.request_locale_provider'),

--- a/tests/Admin/Extension/AbstractTranslatableAdminExtensionTest.php
+++ b/tests/Admin/Extension/AbstractTranslatableAdminExtensionTest.php
@@ -18,6 +18,9 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\TranslationBundle\Admin\Extension\AbstractTranslatableAdminExtension;
 use Sonata\TranslationBundle\Checker\TranslatableChecker;
 use Sonata\TranslationBundle\Provider\LocaleProviderInterface;
+use Sonata\TranslationBundle\Provider\RequestLocaleProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 final class AbstractTranslatableAdminExtensionTest extends TestCase
 {
@@ -47,5 +50,34 @@ final class AbstractTranslatableAdminExtensionTest extends TestCase
         $parameters = $this->extension->configurePersistentParameters(static::createStub(AdminInterface::class), []);
 
         static::assertSame(['tl' => 'es'], $parameters);
+    }
+
+    public function testReset(): void
+    {
+        $request = new Request();
+        $request->query->set(AbstractTranslatableAdminExtension::TRANSLATABLE_LOCALE_PARAMETER, 'cs');
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $localeProvider = new RequestLocaleProvider($requestStack, 'en');
+
+        $translatableChecker = new TranslatableChecker();
+
+        $extension = new
+            /**
+             * @template-extends AbstractTranslatableAdminExtension<object>
+             */
+            class($translatableChecker, $localeProvider) extends AbstractTranslatableAdminExtension {
+                public function getLocalePublicly(): string
+                {
+                    return $this->getTranslatableLocale();
+                }
+            };
+
+        static::assertSame('cs', $extension->getLocalePublicly());
+        $request->query->set(AbstractTranslatableAdminExtension::TRANSLATABLE_LOCALE_PARAMETER, 'es');
+        $localeProvider->reset();
+        static::assertSame('cs', $extension->getLocalePublicly());
+        $extension->reset();
+        static::assertSame('es', $extension->getLocalePublicly());
     }
 }

--- a/tests/Provider/RequestLocaleProviderTest.php
+++ b/tests/Provider/RequestLocaleProviderTest.php
@@ -50,4 +50,21 @@ final class RequestLocaleProviderTest extends TestCase
 
         static::assertSame('en', $requestLocaleProvider->get());
     }
+
+    public function testReset(): void
+    {
+        $request = new Request();
+        $request->query->set(AbstractTranslatableAdminExtension::TRANSLATABLE_LOCALE_PARAMETER, 'cs');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $requestLocaleProvider = new RequestLocaleProvider($requestStack, 'en');
+
+        static::assertSame('cs', $requestLocaleProvider->get());
+        $request->query->set(AbstractTranslatableAdminExtension::TRANSLATABLE_LOCALE_PARAMETER, 'es');
+        static::assertSame('cs', $requestLocaleProvider->get());
+        $requestLocaleProvider->reset();
+        static::assertSame('es', $requestLocaleProvider->get());
+    }
 }


### PR DESCRIPTION
## Subject

Makes the bundle work in long running processes (like Frankenphp, Roadrunner and similar) by implementing the ResetInterface (and tagging the services as `kernel.reset`).

I am targeting this branch, because it's a backwards compatible new feature.

## Changelog

```markdown
### Changed

- Made the `RequestLocaleProvider` and `AbstractTranslatableAdminExtension` implement `ResetInterface` to make it work with long-running processes
```
