### PR TITLE
Allow knplabs/doctrine-behaviors 3.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,6 +47,10 @@ jobs:
                     - php-version: '8.5'
                       dependencies: highest
                       allowed-to-fail: false
+                      variant: knplabs/doctrine-behaviors:"^3.0"
+                    - php-version: '8.5'
+                      dependencies: highest
+                      allowed-to-fail: false
                       symfony-require: 6.4.*
                       variant: symfony/symfony:"6.4.*"
                     - php-version: '8.5'

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "conflict": {
         "doctrine/persistence": "<3.0.2",
         "gedmo/doctrine-extensions": "<3.11",
-        "knplabs/doctrine-behaviors": "<2.6.2 || >=3.0"
+        "knplabs/doctrine-behaviors": "<2.6.2"
     },
     "suggest": {
         "gedmo/doctrine-extensions": "if you translate orm entities with the gedmo extensions",


### PR DESCRIPTION
## Subject

https://github.com/KnpLabs/DoctrineBehaviors release new 3.0 branch with support Symfony 7, ORM 3, DBAL 4.
This PR removes this version from conflict section of composer.json

## Changelog

```markdown
### Changed
- Allowed use of knplabs/doctrine-behaviors 3.0
```
